### PR TITLE
BUG: ensure infinite ACT estimates are properly handled

### DIFF
--- a/bilby/core/sampler/dynesty_utils.py
+++ b/bilby/core/sampler/dynesty_utils.py
@@ -304,7 +304,7 @@ class ACTTrackingRWalk:
         thin = self.thin * iact
 
         if accept == 0:
-            logger.debug(
+            logger.warning(
                 "Unable to find a new point using walk: returning a random point"
             )
             u = common_kwargs["rstate"].uniform(size=len(current_u))

--- a/bilby/core/sampler/dynesty_utils.py
+++ b/bilby/core/sampler/dynesty_utils.py
@@ -50,7 +50,7 @@ class LivePointSampler(UnitCubeSampler):
 
         # update walks to match target naccept
         accept_prob = max(0.5, blob["accept"]) / self.kwargs["walks"]
-        delay = self.nlive // 10 - 1
+        delay = max(self.nlive // 10 - 1, 0)
         n_target = getattr(_SamplingContainer, "naccept", 60)
         self.walks = (self.walks * delay + n_target / accept_prob) / (delay + 1)
         self.kwargs["walks"] = min(int(np.ceil(self.walks)), _SamplingContainer.maxmcmc)
@@ -220,7 +220,7 @@ class ACTTrackingRWalk:
 
         # Setup
         current_u = args.u
-        check_interval = int(np.ceil(self.act))
+        check_interval = self.integer_act
         target_nact = 50
         next_check = check_interval
         n_checks = 0
@@ -300,7 +300,7 @@ class ACTTrackingRWalk:
         )
         reject += nfail
         blob = {"accept": accept, "reject": reject, "scale": args.scale}
-        iact = int(np.ceil(self.act))
+        iact = self.integer_act
         thin = self.thin * iact
 
         if accept == 0:
@@ -358,6 +358,14 @@ class ACTTrackingRWalk:
         else:
             return np.inf
         return max(calculate_tau(samples), naive_act, most_failures)
+    
+    @property
+    def integer_act(self):
+        if np.isinf(self.act):
+            return self.act
+        else:
+            return int(np.ceil(self.act))
+
 
 
 class AcceptanceTrackingRWalk:

--- a/bilby/core/sampler/dynesty_utils.py
+++ b/bilby/core/sampler/dynesty_utils.py
@@ -358,7 +358,7 @@ class ACTTrackingRWalk:
         else:
             return np.inf
         return max(calculate_tau(samples), naive_act, most_failures)
-    
+
     @property
     def integer_act(self):
         if np.isinf(self.act):

--- a/bilby/core/sampler/dynesty_utils.py
+++ b/bilby/core/sampler/dynesty_utils.py
@@ -367,7 +367,6 @@ class ACTTrackingRWalk:
             return int(np.ceil(self.act))
 
 
-
 class AcceptanceTrackingRWalk:
     """
     This is a modified version of dynesty.sampling.sample_rwalk that runs the


### PR DESCRIPTION
@lalit-pathak reported the following error. This happens when no points are accepted during the MCMC while using ACT-walk. This is most likely a sign of some underlying pathology in the likelihood/sampling space, but we should handle the case smoothly.

```python
Traceback (most recent call last):
  File "/home/lalit.pathak/.conda/envs/gwsim_env/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/lalit.pathak/.conda/envs/gwsim_env/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/lalit.pathak/.conda/envs/gwsim_env/lib/python3.10/site-packages/bilby/core/sampler/dynesty_utils.py", line 198, in __call__
    while self.cache[0][2] < args.loglstar:
  File "/home/lalit.pathak/.conda/envs/gwsim_env/lib/python3.10/site-packages/bilby/core/sampler/dynesty_utils.py", line 207, in cache
    self.build_cache()
  File "/home/lalit.pathak/.conda/envs/gwsim_env/lib/python3.10/site-packages/bilby/core/sampler/dynesty_utils.py", line 223, in build_cache
    check_interval = int(np.ceil(self.act))
OverflowError: cannot convert float infinity to integer
```

I also noticed a second case where an infinity can sneak in that will break things, if there are fewer than ten live points, the acceptance walk method will fail on current master.

```python
Traceback (most recent call last):
  File "/Users/colm/modules/bilby/examples/core_examples/linear_regression.py", line 57, in <module>
    result = bilby.run_sampler(
  File "/Users/colm/modules/bilby/bilby/core/sampler/__init__.py", line 234, in run_sampler
    result = sampler.run_sampler()
  File "/Users/colm/modules/bilby/bilby/core/sampler/base_sampler.py", line 97, in wrapped
    output = method(self, *args, **kwargs)
  File "/Users/colm/modules/bilby/bilby/core/sampler/dynesty.py", line 517, in run_sampler
    out = self._run_external_sampler_with_checkpointing()
  File "/Users/colm/modules/bilby/bilby/core/sampler/dynesty.py", line 637, in _run_external_sampler_with_checkpointing
    self.sampler.run_nested(**sampler_kwargs)
  File "/Users/colm/modules/dynesty/py/dynesty/sampler.py", line 1057, in run_nested
    for it, results in enumerate(
  File "/Users/colm/modules/dynesty/py/dynesty/sampler.py", line 877, in sample
    u, v, logl, nc = self._new_point(loglstar_new)
  File "/Users/colm/modules/dynesty/py/dynesty/sampler.py", line 462, in _new_point
    self.update_proposal(blob, update=self.nqueue <= 0)
  File "/Users/colm/modules/bilby/bilby/core/sampler/dynesty_utils.py", line 56, in update_user
    self.walks = (self.walks * delay + n_target / accept_prob) / (delay + 1)
ZeroDivisionError: float division by zero
```

I'm opening this as a test of migrating open MRs from gitlab to here. https://git.ligo.org/lscsoft/bilby/-/merge_requests/1383 is the original MR.