### PR TITLE
BUGFIX: Joint prior subclassing fixes

### DIFF
--- a/bilby/core/prior/joint.py
+++ b/bilby/core/prior/joint.py
@@ -139,7 +139,7 @@ class BaseJointPriorDist(object):
             ]
         )
         return "{}({})".format(dist_name, args)
-    
+
     @classmethod
     def from_repr(cls, string):
         """Generate the distribution from its __repr__"""
@@ -342,7 +342,7 @@ class BaseJointPriorDist(object):
         Here is where the subclass where overwrite rescale method
         """
         return samp
-    
+
     def __eq__(self, other):
         if self.__class__ != other.__class__:
             return False
@@ -720,8 +720,6 @@ class MultivariateGaussianDist(BaseJointPriorDist):
                 if not self.__dict__[key] == other.__dict__[key]:
                     return False
         return True
-
-
 
 
 class MultivariateNormalDist(MultivariateGaussianDist):

--- a/bilby/core/prior/joint.py
+++ b/bilby/core/prior/joint.py
@@ -139,6 +139,38 @@ class BaseJointPriorDist(object):
             ]
         )
         return "{}({})".format(dist_name, args)
+    
+    @classmethod
+    def from_repr(cls, string):
+        """Generate the distribution from its __repr__"""
+        return cls._from_repr(string)
+
+    @classmethod
+    def _from_repr(cls, string):
+        subclass_args = infer_args_from_method(cls.__init__)
+
+        string = string.replace(" ", "")
+        kwargs = cls._split_repr(string)
+        for key in kwargs:
+            val = kwargs[key]
+            if key not in subclass_args:
+                raise AttributeError(
+                    "Unknown argument {} for class {}".format(key, cls.__name__)
+                )
+            else:
+                kwargs[key.strip()] = Prior._parse_argument_string(val)
+
+        return cls(**kwargs)
+
+    @classmethod
+    def _split_repr(cls, string):
+        string = string.replace(",", ", ")
+        # see https://stackoverflow.com/a/72146415/1862861
+        args = re.findall(r"(\w+)=(\[.*?]|{.*?}|\S+)(?=\s*,\s*\w+=|\Z)", string)
+        kwargs = dict()
+        for key, arg in args:
+            kwargs[key.strip()] = arg
+        return kwargs
 
     def prob(self, samp):
         """
@@ -310,6 +342,11 @@ class BaseJointPriorDist(object):
         Here is where the subclass where overwrite rescale method
         """
         return samp
+    
+    def __eq__(self, other):
+        if self.__class__ != other.__class__:
+            return False
+        return self.get_instantiation_dict() == other.get_instantiation_dict()
 
 
 class MultivariateGaussianDist(BaseJointPriorDist):
@@ -684,37 +721,7 @@ class MultivariateGaussianDist(BaseJointPriorDist):
                     return False
         return True
 
-    @classmethod
-    def from_repr(cls, string):
-        """Generate the distribution from its __repr__"""
-        return cls._from_repr(string)
 
-    @classmethod
-    def _from_repr(cls, string):
-        subclass_args = infer_args_from_method(cls.__init__)
-
-        string = string.replace(" ", "")
-        kwargs = cls._split_repr(string)
-        for key in kwargs:
-            val = kwargs[key]
-            if key not in subclass_args:
-                raise AttributeError(
-                    "Unknown argument {} for class {}".format(key, cls.__name__)
-                )
-            else:
-                kwargs[key.strip()] = Prior._parse_argument_string(val)
-
-        return cls(**kwargs)
-
-    @classmethod
-    def _split_repr(cls, string):
-        string = string.replace(",", ", ")
-        # see https://stackoverflow.com/a/72146415/1862861
-        args = re.findall(r"(\w+)=(\[.*?]|{.*?}|\S+)(?=\s*,\s*\w+=|\Z)", string)
-        kwargs = dict()
-        for key, arg in args:
-            kwargs[key.strip()] = arg
-        return kwargs
 
 
 class MultivariateNormalDist(MultivariateGaussianDist):
@@ -736,7 +743,7 @@ class JointPrior(Prior):
         unit: str
             See superclass
         """
-        if not isinstance(BaseJointPriorDist):
+        if not isinstance(dist, BaseJointPriorDist):
             raise TypeError(
                 "Must supply a JointPriorDist object instance to be shared by all joint params"
             )

--- a/bilby/core/prior/joint.py
+++ b/bilby/core/prior/joint.py
@@ -736,7 +736,7 @@ class JointPrior(Prior):
         unit: str
             See superclass
         """
-        if BaseJointPriorDist not in dist.__class__.__bases__:
+        if not isinstance(BaseJointPriorDist):
             raise TypeError(
                 "Must supply a JointPriorDist object instance to be shared by all joint params"
             )

--- a/bilby/core/utils/io.py
+++ b/bilby/core/utils/io.py
@@ -29,7 +29,6 @@ def check_directory_exists_and_if_not_mkdir(directory):
 class BilbyJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         from ..prior import BaseJointPriorDist, Prior, PriorDict
-        from ...gw.prior import HealPixMapPriorDist
         from ...bilby_mcmc.proposals import ProposalCycle
 
         if isinstance(obj, np.integer):

--- a/bilby/core/utils/io.py
+++ b/bilby/core/utils/io.py
@@ -28,7 +28,7 @@ def check_directory_exists_and_if_not_mkdir(directory):
 
 class BilbyJsonEncoder(json.JSONEncoder):
     def default(self, obj):
-        from ..prior import MultivariateGaussianDist, Prior, PriorDict
+        from ..prior import BaseJointPriorDist, Prior, PriorDict
         from ...gw.prior import HealPixMapPriorDist
         from ...bilby_mcmc.proposals import ProposalCycle
 
@@ -38,7 +38,7 @@ class BilbyJsonEncoder(json.JSONEncoder):
             return float(obj)
         if isinstance(obj, PriorDict):
             return {"__prior_dict__": True, "content": obj._get_json_dict()}
-        if isinstance(obj, (MultivariateGaussianDist, HealPixMapPriorDist, Prior)):
+        if isinstance(obj, (BaseJointPriorDist, HealPixMapPriorDist, Prior)):
             return {
                 "__prior__": True,
                 "__module__": obj.__module__,

--- a/bilby/core/utils/io.py
+++ b/bilby/core/utils/io.py
@@ -38,7 +38,7 @@ class BilbyJsonEncoder(json.JSONEncoder):
             return float(obj)
         if isinstance(obj, PriorDict):
             return {"__prior_dict__": True, "content": obj._get_json_dict()}
-        if isinstance(obj, (BaseJointPriorDist, HealPixMapPriorDist, Prior)):
+        if isinstance(obj, (BaseJointPriorDist, Prior)):
             return {
                 "__prior__": True,
                 "__module__": obj.__module__,

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -488,7 +488,6 @@ class TestJsonIO(unittest.TestCase):
 
     def test_read_write_to_json(self):
         """ Interped prior is removed as there is numerical error in the recovered prior."""
-        self.maxDiff = None
         self.priors.to_json(outdir="prior_files", label="json_test")
         new_priors = bilby.core.prior.PriorDict.from_json(
             filename="prior_files/json_test_prior.json"

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -8,7 +8,7 @@ import bilby
 
 
 # needs to be defined on module-level for later re-initialization
-class MVNSubclass(bilby.core.prior.MultivariateGaussianDist):
+class MVNSubclass(bilby.core.prior.MultivariateNormalDist):
     def __init__(self, names, mus, covs, weights):
         super().__init__(names=names, mus=mus, covs=covs, weights=weights)
 
@@ -138,10 +138,15 @@ class TestPriorDict(unittest.TestCase):
         fake_dist = FakeJointPriorDist(names=["testAfake", "testBfake"])
         testAfake = bilby.core.prior.JointPrior(dist=fake_dist, name="testAfake", unit="unit")
         testBfake = bilby.core.prior.JointPrior(dist=fake_dist, name="testBfake", unit="unit")
-        expected_joint = dict(testAfake=testAfake, testBfake=testBfake)
+        base_dist = bilby.core.prior.BaseJointPriorDist(names=["testAbase", "testBbase"])
+        testAbase = bilby.core.prior.JointPrior(dist=base_dist, name="testAbase", unit="unit")
+        testBbase = bilby.core.prior.JointPrior(dist=base_dist, name="testBbase", unit="unit")
+        expected_joint = dict(testAfake=testAfake, testBfake=testBfake, testAbase=testAbase, testBbase=testBbase)
         self.assertDictEqual(expected_joint, self.joint_prior_from_file)
         self.assertTrue(id(self.joint_prior_from_file["testAfake"].dist)
                         == id(self.joint_prior_from_file["testBfake"].dist))
+        self.assertTrue(id(self.joint_prior_from_file["testAbase"].dist)
+                        == id(self.joint_prior_from_file["testBbase"].dist))
 
     def test_to_file(self):
         """
@@ -358,7 +363,7 @@ class TestJsonIO(unittest.TestCase):
             covs=np.array([[2.0, 0.5], [0.5, 2.0]]),
             weights=1.0,
         )
-        mvn = bilby.core.prior.MultivariateGaussianDist(
+        mvn = bilby.core.prior.MultivariateNormalDist(
             names=["testA", "testB"],
             mus=[1, 1],
             covs=np.array([[2.0, 0.5], [0.5, 2.0]]),

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -19,7 +19,7 @@ class FakeJointPriorDist(bilby.core.prior.BaseJointPriorDist):
         super().__init__(names=names, bounds=bounds)
 
 
-setattr(bilby.core.prior, FakeJointPriorDist, FakeJointPriorDist)
+setattr(bilby.core.prior, "FakeJointPriorDist", FakeJointPriorDist)
 
 
 class TestPriorDict(unittest.TestCase):

--- a/test/core/prior/prior_files/joint_prior.prior
+++ b/test/core/prior/prior_files/joint_prior.prior
@@ -1,0 +1,6 @@
+fake_dist = FakeJointPriorDist(names=["testAfake", "testBfake"]) 
+testAfake=bilby.core.prior.JointPrior(dist=fake_dist, name="testAfake", unit="unit")
+testBfake=bilby.core.prior.JointPrior(dist=fake_dist, name="testBfake", unit="unit")
+base_dist = BaseJointPriorDist(names=["testAbase", "testBbase"])
+testAbase=bilby.core.prior.JointPrior(dist=base_dist, name="testAbase", unit="unit")
+testBbase=bilby.core.prior.JointPrior(dist=base_dist, name="testBbase", unit="unit")


### PR DESCRIPTION
This pull request addresses multiple issues with the subclassing of  BaseJointPrior lists and their reinitialization from `json` or `dict` outlined in https://github.com/bilby-dev/bilby/issues/31, implements fixes and also test cases that fail with the old implementation.

The tests uncovered some new issues that required fixes beyond the (current) discussion in https://github.com/bilby-dev/bilby/issues/31. The fixes are implemented by moving some of the logic used to re-initialize (subclasses of) `BaseJointPriorDist` from `MultivariateGaussianDist` to `BaseJointPriorDist`.

The tests also uncovered a problem with `__eq__` for `JointPrior` that resulted in `__eq__` giving `False` if the `dist` keyword does not point to the same instance. This, I felt, was inconsistent with the usage of `__eq__` across `PriorDict`. 

One overall change currently applied by this PR is that it is now easier to, by mistake, use a not-subclassed `BaseJointPriorDist` somewhere. I wonder, however, if the `BaseJointPriorDist` methods that need be subclassed should not raise an `NotImplemented` error anyway.
 