### PR TITLE
FEAT: add argument to specify calibration correction direction

### DIFF
--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -12,7 +12,7 @@ from ...core.prior.dict import PriorDict
 from ..prior import CalibrationPriorDict
 
 
-def read_calibration_file(filename, frequency_array, number_of_response_curves, starting_index=0):
+def read_calibration_file(filename, frequency_array, number_of_response_curves, starting_index=0, correction=None):
     r"""
     Function to read the hdf5 files from the calibration group containing the
     physical calibration response curves.
@@ -33,6 +33,9 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
     starting_index: int
         Index of the first curve to use within the array. This allows for segmenting the calibration curve array
         into smaller pieces.
+    correction: str
+        How the correction is defined, either to the data (default) or
+        the template, see :func:`bilby.gw.prior.CalibrationPriorDict.from_envelope_file`.
 
     Returns
     -------
@@ -42,6 +45,21 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
 
     """
     import tables
+
+    if correction is None:
+        logger.warning(
+            "Calibration envelope correction type is not specified. "
+            "Assuming this correction maps calibrated data to theoretical "
+            "strain. If this is correct, this should be explicitly "
+            "specified via CalibrationPriorDict.from_envelope_file(..., "
+            "correction='data')."
+        )
+        correction = "data"
+    if correction.lower() not in ["data", "template"]:
+        raise ValueError(
+            "Calibration envelope correction should be one of 'data' or "
+            f"'template', found {correction}."
+        )
 
     logger.info(f"Reading calibration draws from {filename}")
     calibration_file = tables.open_file(filename, 'r')
@@ -61,9 +79,11 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
 
     # interpolate to the frequency array (where if outside the range of the calibration uncertainty its fixed to 1)
     calibration_draws = calibration_amplitude * np.exp(1j * calibration_phase)
-    calibration_draws = 1 / interp1d(
+    calibration_draws = interp1d(
         calibration_frequencies, calibration_draws, kind='cubic',
         bounds_error=False, fill_value=1)(frequency_array)
+    if correction == "data":
+        calibration_draws **= -1
 
     try:
         parameter_draws = pd.read_hdf(filename, key="CalParams")
@@ -73,7 +93,7 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
     return calibration_draws, parameter_draws
 
 
-def write_calibration_file(filename, frequency_array, calibration_draws, calibration_parameter_draws=None):
+def write_calibration_file(filename, frequency_array, calibration_draws, calibration_parameter_draws=None, correction=None):
     """
     Function to write the generated response curves to file
 
@@ -88,9 +108,32 @@ def write_calibration_file(filename, frequency_array, calibration_draws, calibra
         Shape is (number_of_response_curves x len(frequency_array))
     calibration_parameter_draws: data_frame
         Parameters used to generate the random draws of the calibration response curves
+    correction: str
+        How the correction is defined, either to the data (default) or
+        the template, see :func:`bilby.gw.prior.CalibrationPriorDict.from_envelope_file`.
+        If :code:`data`, the calibration draws will be inverted before being saved so that the format
+        matches files produced by detector calibration pipelines.
 
     """
     import tables
+
+    if correction is None:
+        logger.warning(
+            "Calibration envelope correction type is not specified. "
+            "Assuming this correction maps calibrated data to theoretical "
+            "strain. If this is correct, this should be explicitly "
+            "specified via CalibrationPriorDict.from_envelope_file(..., "
+            "correction='data')."
+        )
+        correction = "data"
+    if correction.lower() not in ["data", "template"]:
+        raise ValueError(
+            "Calibration envelope correction should be one of 'data' or "
+            f"'template', found {correction}."
+        )
+
+    if correction == "data":
+        calibration_draws **= -1
 
     logger.info(f"Writing calibration draws to {filename}")
     calibration_file = tables.open_file(filename, 'w')

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -13,8 +13,14 @@ from ..prior import CalibrationPriorDict
 
 
 def read_calibration_file(filename, frequency_array, number_of_response_curves, starting_index=0):
-    """
-    Function to read the hdf5 files from the calibration group containing the physical calibration response curves.
+    r"""
+    Function to read the hdf5 files from the calibration group containing the
+    physical calibration response curves.
+
+    These curves are defined to convert calibrated strain (:code:`d`) to
+    theoretical waveform templates (:code:`h`), in the likelihood we apply
+    the correction in the opposite direction and so must invert the curves
+    stored in the file.
 
     Parameters
     ----------
@@ -55,7 +61,7 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
 
     # interpolate to the frequency array (where if outside the range of the calibration uncertainty its fixed to 1)
     calibration_draws = calibration_amplitude * np.exp(1j * calibration_phase)
-    calibration_draws = interp1d(
+    calibration_draws = 1 / interp1d(
         calibration_frequencies, calibration_draws, kind='cubic',
         bounds_error=False, fill_value=1)(frequency_array)
 

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -93,7 +93,9 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
     return calibration_draws, parameter_draws
 
 
-def write_calibration_file(filename, frequency_array, calibration_draws, calibration_parameter_draws=None, correction=None):
+def write_calibration_file(
+    filename, frequency_array, calibration_draws, calibration_parameter_draws=None, correction=None
+):
     """
     Function to write the generated response curves to file
 

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -29,14 +29,14 @@ Clearly, these are related via
     \eta = \frac{1}{\alpha}
 
 Internally, in :code:`Bilby`, the correction is always :math:`\alpha`.
-However, when reading in a production described calibration uncertainty, e.g.,
-uncertainty envelopes or estimated response curves, the user should specify
-which method is being used as :code:`"data"` for :math:`\eta` or
+However, when reading in a data product describing calibration uncertainty,
+e.g., uncertainty envelopes or estimated response curves, the user should
+specify which method is being used as :code:`"data"` for :math:`\eta` or
 :code:`"template"` for :math:`\alpha`.
 
 .. note::
     In general, data products produced by the LVK calibration groups use the
-    :code:`data` convention.
+    :code:`"data"` convention.
 
 """
 import copy

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -32,7 +32,7 @@ Internally, in :code:`Bilby`, the correction is always :math:`\alpha`.
 However, when reading in a production described calibration uncertainty, e.g.,
 uncertainty envelopes or estimated response curves, the user should specify
 which method is being used as :code:`"data"` for :math:`\eta` or
-:code:`"tempalte"` for :math:`\alpha`.
+:code:`"template"` for :math:`\alpha`.
 
 .. note::
     In general, data products produced by the LVK calibration groups use the
@@ -50,26 +50,27 @@ from ...core.utils.log import logger
 from ...core.prior.dict import PriorDict
 from ..prior import CalibrationPriorDict
 
-def _check_calibration_correction_type(correction):
-    if correction is None:
+
+def _check_calibration_correction_type(correction_type):
+    if correction_type is None:
         logger.warning(
             "Calibration envelope correction type is not specified. "
             "Assuming this correction maps calibrated data to theoretical "
             "strain. If this is correct, this should be explicitly "
             "specified via CalibrationPriorDict.from_envelope_file(..., "
-            "correction='data'). The other possibility is correction="
+            "correction_type='data'). The other possibility is correction_type="
             "'template', which maps theoretical strain to calibrated data."
         )
-        correction = "data"
-    if correction.lower() not in ["data", "template"]:
+        correction_type = "data"
+    if correction_type.lower() not in ["data", "template"]:
         raise ValueError(
             "Calibration envelope correction should be one of 'data' or "
-            f"'template', found {correction}."
+            f"'template', found {correction_type}."
         )
     logger.debug(
-        f"Supplied calibration correction will be applied to the {correction}"
+        f"Supplied calibration correction will be applied to the {correction_type}"
     )
-    return correction
+    return correction_type
 
 
 def read_calibration_file(
@@ -107,7 +108,7 @@ def read_calibration_file(
     """
     import tables
 
-    correction = _check_calibration_correction_type(correction=correction)
+    correction_type = _check_calibration_correction_type(correction_type=correction_type)
 
     logger.info(f"Reading calibration draws from {filename}")
     calibration_file = tables.open_file(filename, 'r')
@@ -130,7 +131,7 @@ def read_calibration_file(
     calibration_draws = interp1d(
         calibration_frequencies, calibration_draws, kind='cubic',
         bounds_error=False, fill_value=1)(frequency_array)
-    if correction == "data":
+    if correction_type == "data":
         calibration_draws = 1 / calibration_draws
 
     try:
@@ -142,7 +143,7 @@ def read_calibration_file(
 
 
 def write_calibration_file(
-    filename, frequency_array, calibration_draws, calibration_parameter_draws=None, correction=None
+    filename, frequency_array, calibration_draws, calibration_parameter_draws=None, correction_type=None
 ):
     """
     Function to write the generated response curves to file
@@ -169,9 +170,9 @@ def write_calibration_file(
     """
     import tables
 
-    correction = _check_calibration_correction_type(correction=correction)
+    correction_type = _check_calibration_correction_type(correction_type=correction_type)
 
-    if correction == "data":
+    if correction_type == "data":
         calibration_draws = 1 / calibration_draws
 
     logger.info(f"Writing calibration draws to {filename}")

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -1,4 +1,43 @@
-""" Functions for adding calibration factors to waveform templates.
+r"""
+Functions for adding calibration factors to waveform templates.
+
+The two key quantities are :math:`d`, the (possible mis-)calibrated strain
+data used for the analysis, and :math:`h`, the theoretical strain predicted by
+the waveform model.
+
+There are two conventions in the literature for how to specify calibration
+corrections. People who work on gravitational-wave detector calibration
+typically describe a correction to the data so that the signal matches the
+theoretical prediction
+
+.. math::
+
+    h = \eta d.
+
+However, when performing inference, we are interested in the correction that
+must be applied to the theoretical strain to match the signal contained within
+the data
+
+.. math::
+
+    d = \alpha h.
+
+Clearly, these are related via
+
+.. math::
+
+    \eta = \frac{1}{\alpha}
+
+Internally, in :code:`Bilby`, the correction is always :math:`\alpha`.
+However, when reading in a production described calibration uncertainty, e.g.,
+uncertainty envelopes or estimated response curves, the user should specify
+which method is being used as :code:`"data"` for :math:`\eta` or
+:code:`"tempalte"` for :math:`\alpha`.
+
+.. note::
+    In general, data products produced by the LVK calibration groups use the
+    :code:`data` convention.
+
 """
 import copy
 import os

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -83,7 +83,7 @@ def read_calibration_file(filename, frequency_array, number_of_response_curves, 
         calibration_frequencies, calibration_draws, kind='cubic',
         bounds_error=False, fill_value=1)(frequency_array)
     if correction == "data":
-        calibration_draws **= -1
+        calibration_draws = 1 / calibration_draws
 
     try:
         parameter_draws = pd.read_hdf(filename, key="CalParams")
@@ -135,7 +135,7 @@ def write_calibration_file(
         )
 
     if correction == "data":
-        calibration_draws **= -1
+        calibration_draws = 1 / calibration_draws
 
     logger.info(f"Writing calibration draws to {filename}")
     calibration_file = tables.open_file(filename, 'w')

--- a/bilby/gw/detector/calibration.py
+++ b/bilby/gw/detector/calibration.py
@@ -97,7 +97,8 @@ def read_calibration_file(
         produced by the LVK calibration groups assume :code:`data`.
         The default value will be removed in a future release and
         this will need to be explicitly specified.
-        ..versionadded XYZ
+
+        .. versionadded:: 1.4.0
 
     Returns
     -------
@@ -165,7 +166,8 @@ def write_calibration_file(
         produced by the LVK calibration groups assume :code:`data`.
         The default value will be removed in a future release and
         this will need to be explicitly specified.
-        ..versionadded XYZ
+
+        .. versionadded:: 1.4.0
 
     """
     import tables

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -1153,8 +1153,9 @@ class CalibrationPriorDict(PriorDict):
         literature, one defines the correction as mapping calibrated strain
         to theoretical waveform templates (:code:`data`) and the other as
         mapping theoretical waveform templates to calibrated strain
-        (:code:`template`). Prior to version XYZ, :code:`tempalte` was assumed,
-        the default changed when the :code:`correction` argument was added.
+        (:code:`template`). Prior to version XYZ, :code:`template` was assumed,
+        the default changed to :code:`data` when the :code:`correction` argument
+        was added.
 
         Parameters
         ==========

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -1177,7 +1177,8 @@ class CalibrationPriorDict(PriorDict):
             produced by the LVK calibration groups assume :code:`data`.
             The default value will be removed in a future release and
             this will need to be explicitly specified.
-            ..versionadded XYZ
+
+            .. versionadded:: 1.4.0
 
         Returns
         =======

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -1153,7 +1153,7 @@ class CalibrationPriorDict(PriorDict):
         literature, one defines the correction as mapping calibrated strain
         to theoretical waveform templates (:code:`data`) and the other as
         mapping theoretical waveform templates to calibrated strain
-        (:code:`template`). Prior to version XYZ, :code:`template` was assumed,
+        (:code:`template`). Prior to version 1.4.0, :code:`template` was assumed,
         the default changed to :code:`data` when the :code:`correction` argument
         was added.
 

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -1186,12 +1186,12 @@ class CalibrationPriorDict(PriorDict):
             This includes the frequencies of the nodes which are _not_ sampled.
         """
         from .detector.calibration import _check_calibration_correction_type
-        correction = _check_calibration_correction_type(correction=correction)
+        correction_type = _check_calibration_correction_type(correction_type=correction_type)
 
         calibration_data = np.genfromtxt(envelope_file).T
         log_frequency_array = np.log(calibration_data[0])
 
-        if correction.lower() == "data":
+        if correction_type.lower() == "data":
             amplitude_median = 1 / calibration_data[1] - 1
             phase_median = -calibration_data[2]
             amplitude_sigma = abs(1 / calibration_data[3] - 1 / calibration_data[5]) / 2

--- a/test/gw/detector/calibration_test.py
+++ b/test/gw/detector/calibration_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from parameterized import parameterized
 
 import numpy as np
 from bilby.core.prior import PriorDict
@@ -109,7 +110,8 @@ class TestReadWriteCalibrationDraws(unittest.TestCase):
         self.assertEqual(draws.shape, (self.number_of_draws, sum(self.ifo.frequency_mask)))
         self.assertListEqual(list(self.priors.keys()), list(parameters.keys()))
 
-    def test_read_write_matches(self):
+    @parameterized.expand([("template",), ("data",), (None,)])
+    def test_read_write_matches(self, correction):
         draws, parameters = calibration._generate_calibration_draws(
             self.ifo, self.priors, self.number_of_draws
         )
@@ -119,12 +121,14 @@ class TestReadWriteCalibrationDraws(unittest.TestCase):
             frequency_array=frequencies,
             calibration_draws=draws,
             calibration_parameter_draws=parameters,
+            correction=correction,
         )
         self.assertTrue(os.path.exists(self.filename))
         loaded_draws, loaded_parameters = calibration.read_calibration_file(
             filename=self.filename,
             frequency_array=frequencies,
             number_of_response_curves=self.number_of_draws,
+            correction=correction,
         )
         self.assertLess(np.max(np.abs(loaded_draws - draws)), 1e-13)
         self.assertTrue(parameters.equals(loaded_parameters))

--- a/test/gw/detector/calibration_test.py
+++ b/test/gw/detector/calibration_test.py
@@ -111,7 +111,7 @@ class TestReadWriteCalibrationDraws(unittest.TestCase):
         self.assertListEqual(list(self.priors.keys()), list(parameters.keys()))
 
     @parameterized.expand([("template",), ("data",), (None,)])
-    def test_read_write_matches(self, correction):
+    def test_read_write_matches(self, correction_type):
         draws, parameters = calibration._generate_calibration_draws(
             self.ifo, self.priors, self.number_of_draws
         )
@@ -121,14 +121,14 @@ class TestReadWriteCalibrationDraws(unittest.TestCase):
             frequency_array=frequencies,
             calibration_draws=draws,
             calibration_parameter_draws=parameters,
-            correction=correction,
+            correction_type=correction_type,
         )
         self.assertTrue(os.path.exists(self.filename))
         loaded_draws, loaded_parameters = calibration.read_calibration_file(
             filename=self.filename,
             frequency_array=frequencies,
             number_of_response_curves=self.number_of_draws,
-            correction=correction,
+            correction_type=correction_type,
         )
         self.assertLess(np.max(np.abs(loaded_draws - draws)), 1e-13)
         self.assertTrue(parameters.equals(loaded_parameters))


### PR DESCRIPTION
This PR aims to add sufficient flexibility in reading calibration data products to make sure that we correctly map these to the templates in the likelihood. There are probably additional documentation changes that we will want.