### PR TITLE
[BUG] relative binning - correctly set last bin index

### DIFF
--- a/bilby/gw/likelihood/relative.py
+++ b/bilby/gw/likelihood/relative.py
@@ -318,8 +318,10 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
                 index = np.where(masked_frequency_array == edge)[0][0]
                 masked_bin_inds.append(index)
             # For the last bin, make sure to include
-            # the last point in the frequency array
-            masked_bin_inds[-1] += 1
+            # the last point in the frequency array,
+            # if it's not already included
+            if masked_bin_inds[-1] < len(masked_frequency_array) - 1:
+                masked_bin_inds[-1] += 1
 
             masked_strain = interferometer.frequency_domain_strain[mask]
             masked_h0 = self.per_detector_fiducial_waveforms[interferometer.name][mask]


### PR DESCRIPTION
If the last bin index is already chosen to be the last point in the frequency array, we shouldn't increment by 1, else we have an invalid index.

I observed this with very long injections that have power even at the maximum frequency, and thus, the bin selection will already include the last frequency point in the bin indices.