### PR TITLE
BUG: make `get_cosmology` constistent with `set_cosmology`

### DIFF
--- a/bilby/core/prior/base.py
+++ b/bilby/core/prior/base.py
@@ -363,7 +363,7 @@ class Prior(object):
         args = string.split(',')
         remove = list()
         for ii, key in enumerate(args):
-            for paren_pair in [('(', ')'), ('{', '}')]:
+            for paren_pair in ['()', '{}', '[]']:
                 if paren_pair[0] in key:
                     jj = ii
                     while paren_pair[1] not in args[jj]:

--- a/bilby/core/prior/base.py
+++ b/bilby/core/prior/base.py
@@ -363,12 +363,13 @@ class Prior(object):
         args = string.split(',')
         remove = list()
         for ii, key in enumerate(args):
-            if '(' in key:
-                jj = ii
-                while ')' not in args[jj]:
-                    jj += 1
-                    args[ii] = ','.join([args[ii], args[jj]]).strip()
-                    remove.append(jj)
+            for paren_pair in [('(', ')'), ('{', '}')]:
+                if paren_pair[0] in key:
+                    jj = ii
+                    while paren_pair[1] not in args[jj]:
+                        jj += 1
+                        args[ii] = ','.join([args[ii], args[jj]]).strip()
+                        remove.append(jj)
         remove.reverse()
         for ii in remove:
             del args[ii]

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -38,8 +38,18 @@ def get_cosmology(cosmology=None):
     _set_default_cosmology()
     if cosmology is None:
         cosmology = DEFAULT_COSMOLOGY
+    elif isinstance(cosmology, cosmo.FLRW):
+        cosmology = cosmology
     elif isinstance(cosmology, str):
         cosmology = getattr(cosmo, cosmology)
+    elif isinstance(cosmology, dict):
+        if 'Ode0' in cosmology.keys():
+            if 'w0' in cosmology.keys():
+                cosmology = cosmo.wCDM(**cosmology)
+            else:
+                cosmology = cosmo.LambdaCDM(**cosmology)
+        else:
+            cosmology = cosmo.FlatLambdaCDM(**cosmology)
     return cosmology
 
 
@@ -58,22 +68,7 @@ def set_cosmology(cosmology=None):
             Dictionary with arguments required to instantiate the cosmology
             class.
     """
-    from astropy import cosmology as cosmo
-    _set_default_cosmology()
-    if cosmology is None:
-        cosmology = DEFAULT_COSMOLOGY
-    elif isinstance(cosmology, cosmo.FLRW):
-        cosmology = cosmology
-    elif isinstance(cosmology, str):
-        cosmology = getattr(cosmo, cosmology)
-    elif isinstance(cosmology, dict):
-        if 'Ode0' in cosmology.keys():
-            if 'w0' in cosmology.keys():
-                cosmology = cosmo.wCDM(**cosmology)
-            else:
-                cosmology = cosmo.LambdaCDM(**cosmology)
-        else:
-            cosmology = cosmo.FlatLambdaCDM(**cosmology)
+    cosmology = get_cosmology(cosmology)
     COSMOLOGY[0] = cosmology
     if cosmology.name is not None:
         COSMOLOGY[1] = cosmology.name

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -621,6 +621,10 @@ class TestLoadPriorWithCosmologicalParameters(unittest.TestCase):
         self.assertEqual(cosmology.H0.value, 67.90)
         self.assertEqual(cosmology.Om0, 0.3065)
 
+        dl = 1000.0
+        ln_prob = prior_dict["luminosity_distance"].ln_prob(dl)
+        self.assertEqual(ln_prob, -9.360343006800193)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -618,6 +618,8 @@ class TestLoadPriorWithCosmologicalParameters(unittest.TestCase):
         )
         prior_dict = bilby.gw.prior.BBHPriorDict(filename=prior_file)
         cosmology = prior_dict["luminosity_distance"].cosmology
+        # These values are based on Plank15_LAL as defined in:
+        # https://dcc.ligo.org/DocDB/0167/T2000185/005/LVC_symbol_convention.pdf
         self.assertEqual(cosmology.H0.value, 67.90)
         self.assertEqual(cosmology.Om0, 0.3065)
 

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -609,5 +609,18 @@ class TestFillPrior(unittest.TestCase):
         self.assertIsInstance(self.priors["ra"], bilby.core.prior.Uniform)
 
 
+class TestLoadPriorWithCosmologicalParameters(unittest.TestCase):
+
+    def test_load(self):
+        prior_file = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "prior_files/prior_with_cosmo_params.prior"
+        )
+        prior_dict = bilby.gw.prior.BBHPriorDict(filename=prior_file)
+        cosmology = prior_dict["luminosity_distance"].cosmology
+        self.assertTrue(cosmology.H0 == 67.90)
+        self.assertTrue(cosmology.Om0 == 0.3065)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -618,8 +618,8 @@ class TestLoadPriorWithCosmologicalParameters(unittest.TestCase):
         )
         prior_dict = bilby.gw.prior.BBHPriorDict(filename=prior_file)
         cosmology = prior_dict["luminosity_distance"].cosmology
-        self.assertTrue(cosmology.H0 == 67.90)
-        self.assertTrue(cosmology.Om0 == 0.3065)
+        self.assertEqual(cosmology.H0.value, 67.90)
+        self.assertEqual(cosmology.Om0, 0.3065)
 
 
 if __name__ == "__main__":

--- a/test/core/prior/prior_files/prior_with_cosmo_params.prior
+++ b/test/core/prior/prior_files/prior_with_cosmo_params.prior
@@ -1,0 +1,1 @@
+luminosity_distance = bilby.gw.prior.UniformSourceFrame(name='luminosity_distance', minimum=1e2, maximum=5e3, cosmology={'H0': 67.90, 'Om0': 0.3065})


### PR DESCRIPTION
As it stands, `get_cosmology` does not support the same inputs as `set_cosmology` despite what the doc-string implies.

This PR moves the logic from `set_cosmology` to `get_cosmology`. The former now just calls the latter rather than having duplicate logic.