### PR TITLE
ENH: add Planck15_LAL cosmology

### DIFF
--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -41,7 +41,14 @@ def get_cosmology(cosmology=None):
     elif isinstance(cosmology, cosmo.FLRW):
         cosmology = cosmology
     elif isinstance(cosmology, str):
-        cosmology = getattr(cosmo, cosmology)
+        if cosmology.lower() == "planck15_lal":
+            # Planck15_LAL cosmology as defined in:
+            # https://dcc.ligo.org/DocDB/0167/T2000185/005/LVC_symbol_convention.pdf
+            cosmology = cosmo.FlatLambdaCDM(
+                H0=67.90, Om0=0.3065, name="Planck15_LAL"
+            )
+        else:
+            cosmology = getattr(cosmo, cosmology)
     elif isinstance(cosmology, dict):
         if 'Ode0' in cosmology.keys():
             if 'w0' in cosmology.keys():

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -14,6 +14,20 @@ def _set_default_cosmology():
         COSMOLOGY = [DEFAULT_COSMOLOGY, DEFAULT_COSMOLOGY.name]
 
 
+def get_available_cosmologies():
+    """Get the list of available cosmologies.
+
+    Includes the Planck15_LAL cosmology.
+
+    Returns
+    -------
+    tuple
+        A tuple of strings with the names of the available cosmologies.
+    """
+    from astropy.cosmology.realizations import available
+    return (*available, "Planck15_LAL")
+
+
 def get_cosmology(cosmology=None):
     """
     Get an instance of a astropy.cosmology.FLRW subclass.

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -17,7 +17,7 @@ def _set_default_cosmology():
 def get_available_cosmologies():
     """Get the list of available cosmologies.
 
-    Includes the Planck15_LAL cosmology.
+    Includes the :code:`Planck15_LAL` cosmology and all cosmologies shipped with :code:`astropy`.
 
     Returns
     -------

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -294,7 +294,8 @@ class Cosmological(Interped):
 
     def get_instantiation_dict(self):
         from astropy import units
-        from astropy.cosmology.realizations import available
+        from .cosmology import get_available_cosmologies
+        available = get_available_cosmologies()
         instantiation_dict = super().get_instantiation_dict()
         if self.cosmology.name in available:
             instantiation_dict['cosmology'] = self.cosmology.name

--- a/test/gw/cosmology_test.py
+++ b/test/gw/cosmology_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from astropy.cosmology import WMAP9, Planck15
 from bilby.gw import cosmology
+import lal
 
 
 class TestSetCosmology(unittest.TestCase):
@@ -47,6 +48,30 @@ class TestGetCosmology(unittest.TestCase):
 
     def test_getting_cosmology_with_default(self):
         self.assertEqual(cosmology.get_cosmology().name, "Planck15")
+
+
+class TestPlanck15LALCosmology(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_redshift_to_luminosity_distance(self):
+        z = 1.0
+        cosmo = cosmology.get_cosmology("Planck15_LAL")
+        dist_bilby = cosmo.luminosity_distance(z)
+        # Change to use CreateDefaultCosmologicalParameters once it is
+        # available in a release
+        omega = lal.CreateCosmologicalParameters(
+            h=0.679,
+            om=0.3065,
+            ol=1 - 0.3065,
+            w0=-1.0,
+            w1=0.0,
+            w2=0.0
+        )
+        dist_lal = lal.LuminosityDistance(omega=omega, z=z)
+        # Results are the same to within 9 decimal places
+        self.assertAlmostEqual(dist_bilby.value, dist_lal)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the Planck15_LAL cosmology as defined in: https://dcc.ligo.org/DocDB/0167/T2000185/005/LVC_symbol_convention.pdf

Note: there are additional commits in this PR since it requires the PR listed below. It should be rebased before being reviewed.

Requires: https://github.com/bilby-dev/bilby/pull/828