### PR TITLE
BUG: fix relative binning indices

### DIFF
--- a/bilby/gw/likelihood/relative.py
+++ b/bilby/gw/likelihood/relative.py
@@ -320,7 +320,7 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
             # For the last bin, make sure to include
             # the last point in the frequency array
             # if it is not already included
-            if masked_bin_inds[-1] != (len(masked_frequency_array) - 1):
+            if masked_bin_inds[-1] < (len(masked_frequency_array) - 1):
                 masked_bin_inds[-1] += 1
 
             masked_strain = interferometer.frequency_domain_strain[mask]

--- a/bilby/gw/likelihood/relative.py
+++ b/bilby/gw/likelihood/relative.py
@@ -319,7 +319,9 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
                 masked_bin_inds.append(index)
             # For the last bin, make sure to include
             # the last point in the frequency array
-            masked_bin_inds[-1] += 1
+            # if it is not already included
+            if masked_bin_inds[-1] != (len(masked_frequency_array) - 1):
+                masked_bin_inds[-1] += 1
 
             masked_strain = interferometer.frequency_domain_strain[mask]
             masked_h0 = self.per_detector_fiducial_waveforms[interferometer.name][mask]


### PR DESCRIPTION
In some cases, the relative binning likelihood would fail due the final index being invalid.

I think this is all that is needed to fix it but others should comment. I've tested the GW190425 example, and it runs after this change.

Closes https://github.com/bilby-dev/bilby/issues/830
