### PR TITLE
Remove double-backslashes from latex labels passed to matplotlib.

### DIFF
--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -1023,6 +1023,7 @@ class Result(object):
         import matplotlib.pyplot as plt
         logger.info('Plotting {} marginal distribution'.format(key))
         label = self.get_latex_labels_from_parameter_keys([key])[0]
+        label = sanity_check_labels([label])[0]
         fig, ax = plt.subplots()
         try:
             ax.hist(self.posterior[key].values, bins=bins, density=True,
@@ -2235,7 +2236,8 @@ def sanity_check_labels(labels):
     """ Check labels for plotting to remove matplotlib errors """
     for ii, lab in enumerate(labels):
         if "_" in lab and "$" not in lab:
-            labels[ii] = lab.replace("_", "-")
+            lab = lab.replace("_", "-")
+        labels[ii] = lab.replace("\\\\", "\\")
     return labels
 
 


### PR DESCRIPTION
Addresses #836 
As far as I can tell, the issue is due to a bug in bilby_pipe, but I noticed that there is already a function to remove matplotlib errors in bilby/core/result.py.

This PR simply adds a line to this function to convert "\\" into "\".

Either way I think this is a good thing to have, as I can't think of a scenario where having "\\" in a matplotlib latex string is a good idea.