### PR TITLE
ENH: implement time marginalization into multiband likelihood

### DIFF
--- a/test/gw/likelihood/marginalization_test.py
+++ b/test/gw/likelihood/marginalization_test.py
@@ -165,7 +165,7 @@ class TestMarginalizations(unittest.TestCase):
     The `time_jitter` parameter makes this a weaker dependence during sampling.
     """
     _parameters = product(
-        ["regular", "roq", "relbin"],
+        ["regular", "roq", "relbin", "multiband"],
         ["luminosity_distance", "geocent_time", "phase"],
         [True, False],
         [True, False],
@@ -268,6 +268,17 @@ class TestMarginalizations(unittest.TestCase):
             )
         )
 
+        self.multiband_waveform_generator = bilby.gw.WaveformGenerator(
+            duration=self.duration,
+            sampling_frequency=self.sampling_frequency,
+            frequency_domain_source_model=bilby.gw.source.binary_black_hole_frequency_sequence,
+            start_time=1126259640,
+            waveform_arguments=dict(
+                reference_frequency=20.0,
+                waveform_approximant="IMRPhenomPv2",
+            )
+        )
+
     def tearDown(self):
         del self.duration
         del self.sampling_frequency
@@ -313,6 +324,12 @@ class TestMarginalizations(unittest.TestCase):
         elif kind == "relbin":
             kwargs["fiducial_parameters"] = deepcopy(self.parameters)
             kwargs["waveform_generator"] = self.relbin_waveform_generator
+        elif kind == "multiband":
+            kwargs["waveform_generator"] = self.multiband_waveform_generator
+            kwargs["reference_chirp_mass"] = (
+                (self.parameters["mass_1"] * self.parameters["mass_2"])**0.6 /
+                (self.parameters["mass_1"] + self.parameters["mass_2"])**0.2
+            )
         return kwargs
 
     def get_likelihood(
@@ -334,6 +351,8 @@ class TestMarginalizations(unittest.TestCase):
             cls_ = bilby.gw.likelihood.RelativeBinningGravitationalWaveTransient
             kwargs["epsilon"] = 0.1
             self.parameters["fiducial"] = 0
+        elif kind == "multiband":
+            cls_ = bilby.gw.likelihood.MBGravitationalWaveTransient
         else:
             raise ValueError(f"kind {kind} not understood")
         like = cls_(**kwargs)
@@ -414,7 +433,7 @@ class TestMarginalizations(unittest.TestCase):
         )
 
     @parameterized.expand(
-        itertools.product(["regular", "roq", "relbin"], *itertools.repeat([True, False], 3)),
+        itertools.product(["regular", "roq", "relbin", "multiband"], *itertools.repeat([True, False], 3)),
         name_func=lambda func, num, param: (
             f"{func.__name__}_{num}__{param.args[0]}_" + "_".join([
                 ["D", "P", "T"][ii] for ii, val


### PR DESCRIPTION
This MR implements time marginalization into multiband likelihood. Time marginalization for multiband may be useful since the slow down factor of time marginalization is not as large as that for ROQ or relative binning. The plots below show the likelihood evaluation time of multiband/standard likelihood and with/without time marginalization for 16s XPHM, 64s XPHM, and 128s Pv2_NRtidalv2. The slow down is less than 2 for the first 2 cases.

![16s_xphm](https://github.com/user-attachments/assets/9ae9eca2-45f3-4963-b3a7-0bf734e6e9df)

![64s_xphm_v2](https://github.com/user-attachments/assets/3689635b-65e9-49b8-bd3d-bf1a432a98d1)

![128s_pv2nrtidalv2](https://github.com/user-attachments/assets/eb5cf65f-ef80-4211-9452-cd28ede7dd9e)

