### PR TITLE
REFACTOR: make multiband likelihood call Interferometer.get_detector_response

### DIFF
--- a/bilby/gw/likelihood/multiband.py
+++ b/bilby/gw/likelihood/multiband.py
@@ -715,26 +715,13 @@ class MBGravitationalWaveTransient(GravitationalWaveTransient):
             An object containing the SNR quantities.
 
         """
-        strain = np.zeros(len(self.banded_frequency_points), dtype=complex)
-        for mode in waveform_polarizations:
-            response = interferometer.antenna_response(
-                self.parameters['ra'], self.parameters['dec'],
-                self.parameters['geocent_time'], self.parameters['psi'],
-                mode
-            )
-            strain += waveform_polarizations[mode][self.unique_to_original_frequencies] * response
-
-        dt = interferometer.time_delay_from_geocenter(
-            self.parameters['ra'], self.parameters['dec'],
-            self.parameters['geocent_time'])
-        dt_geocent = self.parameters['geocent_time'] - interferometer.strain_data.start_time
-        ifo_time = dt_geocent + dt
-
-        calib_factor = interferometer.calibration_model.get_calibration_factor(
-            self.banded_frequency_points, prefix='recalib_{}_'.format(interferometer.name), **self.parameters)
-
-        strain *= np.exp(-1j * 2. * np.pi * self.banded_frequency_points * ifo_time)
-        strain *= calib_factor
+        modes = {
+            mode: value[self.unique_to_original_frequencies]
+            for mode, value in waveform_polarizations.items()
+        }
+        strain = interferometer.get_detector_response(
+            modes, self.parameters, frequencies=self.banded_frequency_points
+        )
 
         d_inner_h = np.conj(np.dot(strain, self.linear_coeffs[interferometer.name]))
 


### PR DESCRIPTION
See https://git.ligo.org/lscsoft/bilby/-/merge_requests/1379

I think this has a conflict with https://github.com/bilby-dev/bilby/pull/842.

Based on ongoing discussion about implementing different detector responses, it would be nice for the likelihoods to all access the response functions uniformly. The MB likelihood currently has an almost verbatim copy of the Inteferometer.get_detector_response method. This MR provides a minimal change to be able to directly call that method.…response