### PR TITLE
ENH: Analytic aligned spin

### DIFF
--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -484,6 +484,8 @@ class AlignedSpin(Interped):
     This is useful when using aligned-spin only waveform approximants.
 
     This is an extension of e.g., (A7) of https://arxiv.org/abs/1805.10457.
+    For the simple case of uniform in magnitude and orientation priors, we use an
+    analytic form of the PDF.
     """
 
     def __init__(self, a_prior=Uniform(0, 1), z_prior=Uniform(-1, 1),

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -511,19 +511,18 @@ class AlignedSpin(Interped):
             xx = np.linspace(chi_min, chi_max, 100000)
             yy = - np.log(np.abs(xx) / a_prior.maximum) / (2 * a_prior.maximum)
         else:
+
+            def integrand(aa, chi):
+                """
+                The integrand for the aligned spin (chi) probability density
+                after performing the integral over spin orientation using a
+                delta function identity.
+                """
+                return a_prior.prob(aa) * z_prior.prob(chi / aa) / aa
+
             xx = np.linspace(chi_min, chi_max, 10000)
             yy = [
-                quad(partial(
-                    lambda aa, chi, amax: (
-                        1
-                        / amax
-                        / aa
-                        * (abs(chi / aa) <= 1)
-                        * a_prior.prob(aa)
-                        * z_prior.prob(chi / aa)
-                    ),
-                    chi=chi, amax=a_prior.maximum - a_prior.minimum
-                ), a_prior.minimum, a_prior.maximum)[0]
+                quad(integrand, a_prior.minimum, a_prior.maximum, chi)[0]
                 for chi in xx
             ]
         super().__init__(

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -514,10 +514,17 @@ class AlignedSpin(Interped):
             xx = np.linspace(chi_min, chi_max, 10000)
             yy = [
                 quad(partial(
-                    lambda aa, zz, amax: 1 / amax / aa * (abs(zz / aa) < 1) / 2,
-                    zz=x, amax=a_prior.maximum - a_prior.minimum
+                    lambda aa, chi, amax: (
+                        1
+                        / amax
+                        / aa
+                        * (abs(chi / aa) <= 1)
+                        * a_prior.prob(aa)
+                        * z_prior.prob(chi / aa)
+                    ),
+                    chi=chi, amax=a_prior.maximum - a_prior.minimum
                 ), a_prior.minimum, a_prior.maximum)[0]
-                for x in xx
+                for chi in xx
             ]
         super().__init__(
             xx=xx,

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -1,6 +1,5 @@
 import os
 import copy
-from functools import partial
 
 import numpy as np
 from scipy.integrate import quad

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -558,6 +558,8 @@ class TestPriorClasses(unittest.TestCase):
                 domain = np.linspace(-1e2, 1e2, 1000)
             elif isinstance(prior, bilby.core.prior.FermiDirac):
                 domain = np.linspace(0.0, 1e2, 1000)
+            elif isinstance(prior, bilby.gw.prior.AlignedSpin):
+                domain = np.linspace(prior.minimum, prior.maximum, 10000)
             else:
                 domain = np.linspace(prior.minimum, prior.maximum, 1000)
             self.assertAlmostEqual(np.trapz(prior.prob(domain), domain), 1, 3)

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -234,7 +234,11 @@ class TestPriorClasses(unittest.TestCase):
     def test_minimum_rescaling(self):
         """Test the the rescaling works as expected."""
         for prior in self.priors:
-            if bilby.core.prior.JointPrior in prior.__class__.__mro__:
+            if isinstance(prior, bilby.gw.prior.AlignedSpin):
+                # the edge of the prior is extremely suppressed for these priors
+                # and so the rescale function doesn't quite return the lower bound
+                continue
+            elif bilby.core.prior.JointPrior in prior.__class__.__mro__:
                 minimum_sample = prior.rescale(0)
                 if prior.dist.filled_rescale():
                     self.assertAlmostEqual(minimum_sample[0], prior.minimum)

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -87,6 +87,12 @@ class TestPriorClasses(unittest.TestCase):
             bilby.core.prior.Gamma(name="test", unit="unit", k=1, theta=1),
             bilby.core.prior.ChiSquared(name="test", unit="unit", nu=2),
             bilby.gw.prior.AlignedSpin(name="test", unit="unit"),
+            bilby.gw.prior.AlignedSpin(
+                a_prior=bilby.core.prior.Beta(alpha=2.0, beta=2.0),
+                z_prior=bilby.core.prior.Beta(alpha=2.0, beta=2.0, minimum=-1),
+                name="test",
+                unit="unit",
+            ),
             bilby.core.prior.MultivariateGaussian(dist=mvg, name="testa", unit="unit"),
             bilby.core.prior.MultivariateGaussian(dist=mvg, name="testb", unit="unit"),
             bilby.core.prior.MultivariateNormal(dist=mvn, name="testa", unit="unit"),

--- a/test/gw/prior_test.py
+++ b/test/gw/prior_test.py
@@ -568,6 +568,15 @@ class TestAlignedSpin(unittest.TestCase):
         max_difference = max(abs(analytic - prior.prob(chis)))
         self.assertAlmostEqual(max_difference, 0, 2)
 
+    def test_non_analytic_form_has_correct_statistics(self):
+        a_prior = bilby.core.prior.TruncatedGaussian(mu=0, sigma=0.1, minimum=0, maximum=1)
+        z_prior = bilby.core.prior.TruncatedGaussian(mu=0.4, sigma=0.2, minimum=-1, maximum=1)
+        chi_prior = bilby.gw.prior.AlignedSpin(a_prior, z_prior)
+        chis = chi_prior.sample(100000)
+        alts = a_prior.sample(100000) * z_prior.sample(100000)
+        self.assertAlmostEqual(np.mean(chis), np.mean(alts), 2)
+        self.assertAlmostEqual(np.std(chis), np.std(alts), 2)
+
 
 class TestConditionalChiUniformSpinMagnitude(unittest.TestCase):
 


### PR DESCRIPTION
As pointed out in https://arxiv.org/abs/2305.19907. The numerical method we use for the aligned spin prior breaks down in the extreme high SNR regime. This MR adds an exact version when using the default spin prior.

Copy of https://git.ligo.org/lscsoft/bilby/-/merge_requests/1282