### PR TITLE
Optimized rescale methods

### DIFF
--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -607,11 +607,12 @@ class PriorDict(dict):
         =======
         list: List of floats containing the rescaled sample
         """
-        from matplotlib.cbook import flatten
-
-        return list(
-            flatten([self[key].rescale(sample) for key, sample in zip(keys, theta)])
-        )
+        theta = list(theta)
+        samples = []
+        for key, units in zip(keys, theta):
+            samps = self[key].rescale(units)
+            samples += list(np.asarray(samps).flatten())
+        return samples
 
     def test_redundancy(self, key, disable_logging=False):
         """Empty redundancy test, should be overwritten in subclasses"""
@@ -838,8 +839,6 @@ class ConditionalPriorDict(PriorDict):
         =======
         list: List of floats containing the rescaled sample
         """
-        from matplotlib.cbook import flatten
-
         keys = list(keys)
         theta = list(theta)
         self._check_resolved()
@@ -852,7 +851,10 @@ class ConditionalPriorDict(PriorDict):
                 theta[index], **self.get_required_variables(key)
             )
             self[key].least_recently_sampled = result[key]
-        return list(flatten([result[key] for key in keys]))
+        samples = []
+        for key in keys:
+            samples += list(np.asarray(result[key]).flatten())
+        return samples
 
     def _update_rescale_keys(self, keys):
         if not keys == self._least_recently_rescaled_keys:


### PR DESCRIPTION
I have noticed that for larger numbers of samples, `PriorDict.rescale` becomes quite slow due to the `flatten` operation, which iterates over all entries with a (slow) native python for loop. 

The following PR provides a relatively simple fix that should be able to handle anything `rescale` methods can reasonably throw at it. In my testing, for only one sample, the new version is roughly equivalent to the old version (if anything slightly faster already). For larger counts, the new method is significantly faster.

On a related note, would it not make sense to let the return value have the appropriate shape for `rescale`s of more than one sample? 