### PR TITLE
MAINT: remove scipy pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ corner
 numpy
 matplotlib
 # see https://github.com/healpy/healpy/pull/953
-scipy>=1.5,<1.14
+scipy>=1.5
 pandas
 dill
 tqdm


### PR DESCRIPTION
This should have been reverted after https://git.ligo.org/lscsoft/bilby/-/merge_requests/1368, but we never did.