### PR TITLE
FEAT: Fix abs/rel path priority in result files.

### DIFF
--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -274,6 +274,19 @@ class TestResult(unittest.TestCase):
         self.result.save_to_file(overwrite=False, extension=extension)
         self.assertTrue(os.path.isfile(f"{self.result.outdir}/{self.result.label}_result.{extension}.old"))
 
+    def _save_with_outdir_and_filename(self, filename, outdir, template):
+        self.result.save_to_file(filename=filename, outdir=outdir, extension="json", gzip=False)
+        self.assertTrue(os.path.isfile(template))
+
+    def test_save_with_outdir_and_filename(self):
+        self._save_with_outdir_and_filename("out/result", "out2", "out2/result.json")
+        self._save_with_outdir_and_filename("out/result", None, "out/result.json")
+        self._save_with_outdir_and_filename("result", "out", "out/result.json")
+        self._save_with_outdir_and_filename(
+            "result", None, os.path.join(self.result.outdir, "result.json"))
+        self._save_with_outdir_and_filename(
+            None, "out", os.path.join("out", f"{self.result.label}_result.json"))
+
     def test_save_and_overwrite_json(self):
         self._save_and_overwrite_test(extension='json')
 


### PR DESCRIPTION
Transfer of https://git.ligo.org/lscsoft/bilby/-/merge_requests/1347

BUG: Make sure outdir is not ignored unnecessarily on manual saving of result file.