### PR TITLE
CI: specify `needs` for `pypi-publish`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
+    needs:
+      - build
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
Add `needs` to the `pypi-published` step of the `publish.yml` workflow.

This ensured `pypi-published` runs _after_ `build`.

Close #860 