### PR TITLE
ENH: add cosmology to CBC result

### DIFF
--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -251,6 +251,14 @@ def run_sampler(
     meta_data["likelihood"] = likelihood.meta_data
     meta_data["loaded_modules"] = loaded_modules_dict()
     meta_data["environment_packages"] = env_package_list(as_dataframe=True)
+    # Add the cosmology if available
+    if "cosmology" not in meta_data:
+        try:
+            from bilby.gw.cosmology import get_cosmology
+
+            meta_data["cosmology"] = get_cosmology()
+        except ImportError:
+            logger.info("Could not specify cosmology in meta data")
 
     if command_line_args.bilby_zero_likelihood_mode:
         from bilby.core.likelihood import ZeroLikelihood

--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -251,14 +251,6 @@ def run_sampler(
     meta_data["likelihood"] = likelihood.meta_data
     meta_data["loaded_modules"] = loaded_modules_dict()
     meta_data["environment_packages"] = env_package_list(as_dataframe=True)
-    # Add the cosmology if available
-    if "cosmology" not in meta_data:
-        try:
-            from bilby.gw.cosmology import get_cosmology
-
-            meta_data["cosmology"] = get_cosmology()
-        except ImportError:
-            logger.info("Could not specify cosmology in meta data")
 
     if command_line_args.bilby_zero_likelihood_mode:
         from bilby.core.likelihood import ZeroLikelihood

--- a/bilby/core/utils/io.py
+++ b/bilby/core/utils/io.py
@@ -157,11 +157,11 @@ def decode_astropy_cosmology(dct):
     except KeyError:
         # Support decoding result files that used the previous encoding
         logger.warning(
-            "Failed to decode cosmology, falling back to legacy decoding."
+            "Failed to decode cosmology, falling back to legacy decoding. "
             "Support for legacy decoding will be removed in a future release."
         )
         cosmo_cls = getattr(cosmo, dct["__name__"])
-        del dct["__cosmology__"], dct["__name__"]
+        del dct["__name__"]
         return cosmo_cls(**dct)
 
 

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -117,6 +117,18 @@ class CompactBinaryCoalescenceResult(CoreResult):
         return self.__get_from_nested_meta_data(
             'likelihood', 'parameter_conversion')
 
+    @property
+    def cosmology(self):
+        """The global cosmology used in the analysis.
+
+        If the cosmology is not set, the default cosmology is returned.
+        See :py:func:`bilby.gw.cosmology.get_cosmology` for details.
+
+        .. versionadded:: 2.5.0
+        """
+        from .cosmology import get_cosmology
+        return get_cosmology()
+
     def detector_injection_properties(self, detector):
         """ Returns a dictionary of the injection properties for each detector
 

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -19,6 +19,14 @@ class CompactBinaryCoalescenceResult(CoreResult):
     of compact binaries.
     """
     def __init__(self, **kwargs):
+
+        # Ensure cosmology is always stored in the meta_data
+        if "meta_data" not in kwargs:
+            kwargs["meta_data"] = dict()
+        if "cosmology" not in kwargs["meta_data"]:
+            from .cosmology import get_cosmology
+            kwargs["meta_data"]["cosmology"] = get_cosmology()
+
         super(CompactBinaryCoalescenceResult, self).__init__(**kwargs)
 
     def __get_from_nested_meta_data(self, *keys):
@@ -121,13 +129,9 @@ class CompactBinaryCoalescenceResult(CoreResult):
     def cosmology(self):
         """The global cosmology used in the analysis.
 
-        If the cosmology is not set, the default cosmology is returned.
-        See :py:func:`bilby.gw.cosmology.get_cosmology` for details.
-
         .. versionadded:: 2.5.0
         """
-        from .cosmology import get_cosmology
-        return get_cosmology()
+        return self.__get_from_nested_meta_data('cosmology')
 
     def detector_injection_properties(self, detector):
         """ Returns a dictionary of the injection properties for each detector

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -20,12 +20,14 @@ class CompactBinaryCoalescenceResult(CoreResult):
     """
     def __init__(self, **kwargs):
 
-        # Ensure cosmology is always stored in the meta_data
         if "meta_data" not in kwargs:
             kwargs["meta_data"] = dict()
-        if "cosmology" not in kwargs["meta_data"]:
+        if "global_meta_data" not in kwargs:
+            kwargs["meta_data"]["global_meta_data"] = dict()
+        # Ensure cosmology is always stored in the meta_data
+        if "cosmology" not in kwargs["meta_data"]["global_meta_data"]:
             from .cosmology import get_cosmology
-            kwargs["meta_data"]["cosmology"] = get_cosmology()
+            kwargs["meta_data"]["global_meta_data"]["cosmology"] = get_cosmology()
 
         super(CompactBinaryCoalescenceResult, self).__init__(**kwargs)
 
@@ -131,7 +133,9 @@ class CompactBinaryCoalescenceResult(CoreResult):
 
         .. versionadded:: 2.5.0
         """
-        return self.__get_from_nested_meta_data('cosmology')
+        return self.__get_from_nested_meta_data(
+            'global_meta_data', 'cosmology'
+        )
 
     def detector_injection_properties(self, detector):
         """ Returns a dictionary of the injection properties for each detector

--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -4,6 +4,7 @@ import pandas as pd
 import shutil
 import os
 import json
+import pytest
 from unittest.mock import patch
 
 import bilby
@@ -11,6 +12,7 @@ from bilby.core.result import ResultError
 
 
 class TestJson(unittest.TestCase):
+
     def setUp(self):
         self.encoder = bilby.core.utils.BilbyJsonEncoder
         self.decoder = bilby.core.utils.decode_bilby_json
@@ -50,6 +52,12 @@ class TestJson(unittest.TestCase):
 
 
 class TestResult(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def init_outdir(self, tmp_path):
+        # Use pytest's tmp_path fixture to create a temporary directory
+        self.outdir = str(tmp_path / "test")
+
     def setUp(self):
         np.random.seed(7)
         bilby.utils.command_line_args.bilby_test_mode = False
@@ -61,7 +69,6 @@ class TestResult(unittest.TestCase):
                 d=2,
             )
         )
-        self.outdir = "test_outdir"
         result = bilby.core.result.Result(
             label="label",
             outdir=self.outdir,
@@ -543,18 +550,32 @@ class TestResult(unittest.TestCase):
             pass
 
         result = bilby.run_sampler(
-            likelihood, priors, sampler='bilby_mcmc', nsamples=10, L1steps=1,
-            proposal_cycle="default_noGMnoKD", printdt=1,
+            likelihood,
+            priors,
+            sampler='bilby_mcmc',
+            outdir=self.outdir,
+            nsamples=10,
+            L1steps=1,
+            proposal_cycle="default_noGMnoKD",
+            printdt=1,
             check_point_plot=False,
-            result_class=NotAResult)
+            result_class=NotAResult
+        )
         # result should be specified result_class
         assert isinstance(result, NotAResult)
 
         cached_result = bilby.run_sampler(
-            likelihood, priors, sampler='bilby_mcmc', nsamples=10, L1steps=1,
-            proposal_cycle="default_noGMnoKD", printdt=1,
+            likelihood,
+            priors,
+            sampler='bilby_mcmc',
+            outdir=self.outdir,
+            nsamples=10,
+            L1steps=1,
+            proposal_cycle="default_noGMnoKD",
+            printdt=1,
             check_point_plot=False,
-            result_class=NotAResult)
+            result_class=NotAResult
+        )
 
         # so should a result loaded from cache
         assert isinstance(cached_result, NotAResult)

--- a/test/gw/result_test.py
+++ b/test/gw/result_test.py
@@ -3,7 +3,6 @@ import shutil
 import unittest
 
 import pandas as pd
-from parameterized import parameterized
 
 import bilby
 
@@ -201,14 +200,11 @@ class TestCBCResult(unittest.TestCase):
             self.result.detector_injection_properties("not_a_detector"), None
         )
 
-    @parameterized.expand(["Planck18", "Planck15", "Planck15_LAL"])
-    def test_cosmology(self, cosmology):
-        from bilby.gw.cosmology import get_cosmology, set_cosmology
-        set_cosmology(cosmology)
-        cosmo = get_cosmology()
-        self.assertEqual(self.result.cosmology, cosmo)
-        # Reset the cosmology to the default
-        set_cosmology("Planck15")
+    def test_cosmology(self):
+        self.assertEqual(
+            self.result.cosmology,
+            self.meta_data["cosmology"],
+        )
 
 
 if __name__ == "__main__":

--- a/test/gw/result_test.py
+++ b/test/gw/result_test.py
@@ -1,13 +1,20 @@
 import os
-import shutil
 import unittest
 
 import pandas as pd
+from parameterized import parameterized, parameterized_class
+import pytest
 
 import bilby
 
 
-class TestCBCResult(unittest.TestCase):
+class BaseCBCResultTest(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def init_outdir(self, tmp_path):
+        # Use pytest's tmp_path fixture to create a temporary directory
+        self.outdir = str(tmp_path / "test")
+
     def setUp(self):
         bilby.utils.command_line_args.bilby_test_mode = False
         priors = bilby.gw.prior.BBHPriorDict()
@@ -35,7 +42,7 @@ class TestCBCResult(unittest.TestCase):
         )
         self.result = bilby.gw.result.CBCResult(
             label="label",
-            outdir="outdir",
+            outdir=self.outdir,
             sampler="nestle",
             search_parameter_keys=list(priors.keys()),
             fixed_parameter_keys=list(),
@@ -50,11 +57,10 @@ class TestCBCResult(unittest.TestCase):
 
     def tearDown(self):
         bilby.utils.command_line_args.bilby_test_mode = True
-        try:
-            shutil.rmtree(self.result.outdir)
-        except OSError:
-            pass
         del self.result
+
+
+class TestCBCResult(BaseCBCResultTest):
 
     def test_phase_marginalization(self):
         self.assertEqual(
@@ -205,6 +211,46 @@ class TestCBCResult(unittest.TestCase):
             self.result.cosmology,
             self.meta_data["cosmology"],
         )
+
+
+@parameterized_class(
+    ["cosmology_name"],
+    [["Planck15"], ["Planck15_LAL"]]
+)
+class TestCBCResultSaveAndLoad(BaseCBCResultTest):
+
+    def setUp(self):
+        self.orig_cosmology = bilby.gw.cosmology.get_cosmology()
+        bilby.gw.cosmology.set_cosmology(self.cosmology_name)
+        return super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        bilby.gw.cosmology.set_cosmology(self.orig_cosmology)
+
+    @parameterized.expand(
+        [
+            ("json", False),
+            ("json", True),
+            ("pkl", False),
+            ("hdf5", False),
+        ]
+    )
+    def test_save_and_load(self, extension, gzip):
+        self.result.save_to_file(extension=extension, gzip=gzip)
+        loaded_result = bilby.core.result.read_in_result(
+            outdir=self.result.outdir,
+            label=self.result.label,
+            extension=extension,
+            gzip=gzip,
+            result_class=bilby.gw.result.CBCResult,
+        )
+        self.assertEqual(self.result.cosmology, loaded_result.cosmology)
+        self.assertEqual(self.result.parameter_conversion, loaded_result.parameter_conversion)
+        self.assertEqual(self.result.frequency_domain_source_model, loaded_result.frequency_domain_source_model)
+        self.assertEqual(self.result.waveform_generator_class, loaded_result.waveform_generator_class)
+        self.assertEqual(self.result.waveform_arguments, loaded_result.waveform_arguments)
+        self.assertEqual(self.result.interferometers, loaded_result.interferometers)
 
 
 if __name__ == "__main__":

--- a/test/gw/result_test.py
+++ b/test/gw/result_test.py
@@ -209,7 +209,7 @@ class TestCBCResult(BaseCBCResultTest):
     def test_cosmology(self):
         self.assertEqual(
             self.result.cosmology,
-            self.meta_data["cosmology"],
+            self.meta_data["global_meta_data"]["cosmology"],
         )
 
 

--- a/test/gw/result_test.py
+++ b/test/gw/result_test.py
@@ -3,6 +3,7 @@ import shutil
 import unittest
 
 import pandas as pd
+from parameterized import parameterized
 
 import bilby
 
@@ -199,6 +200,15 @@ class TestCBCResult(unittest.TestCase):
         self.assertEqual(
             self.result.detector_injection_properties("not_a_detector"), None
         )
+
+    @parameterized.expand(["Planck18", "Planck15", "Planck15_LAL"])
+    def test_cosmology(self, cosmology):
+        from bilby.gw.cosmology import get_cosmology, set_cosmology
+        set_cosmology(cosmology)
+        cosmo = get_cosmology()
+        self.assertEqual(self.result.cosmology, cosmo)
+        # Reset the cosmology to the default
+        set_cosmology("Planck15")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `cosmology` to the `CompactBinaryCoalescenceResult`.

If we run analyses with a different cosmology, I think this should be recorded in the result file. My proposal is to add the `cosmology` in a new dictionary within `meta_data` called `global_meta_data`. This is inline with the changes proposed in https://github.com/bilby-dev/bilby/pull/873. I've implemented it following the same pattern used for other properties, such as the waveform arguments.

Whilst making these changes, I realised that for this to work, the encoding/decoding on astropy objects wasn't working correctly for `hdf5` files. So a lot of changes are related to this.

**Changes**

- Add `cosmology` to the meta data dictionary when calling run sampler
- Add `cosmology` to the meta data dictionary when making an instance of `CompactBinaryCoalescenceResult`
- Improve `encode/decode_astropy_cosmology/quantity` to make use of built-in astropy functions and to more closely match the `JsonCustomEncode` implemented in astropy. The `decode` functions should be backwards compatible.
- Add `encode/decode_astropy_unit`
- Add `decode_hdf5_dict` to ensure astropy types are decoded
- Add tests to ensure the result objects with cosmology can be saved to all available formats
- Improved/added doc-strings for various methods