### PR TITLE
ENH: add cosmology to `CBCPriorDict`

### DIFF
--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -814,9 +814,9 @@ class CBCPriorDict(ConditionalPriorDict):
 
     @property
     def _cosmological_priors(self):
-        return {
+        return [
             key for key, prior in self.items() if isinstance(prior, Cosmological)
-        }
+        ]
 
     @property
     def is_cosmological(self):

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -812,6 +812,68 @@ class CBCPriorDict(ConditionalPriorDict):
         """ Return true if priors include phase parameters """
         return self.is_nonempty_intersection("phase")
 
+    @property
+    def _cosmological_priors(self):
+        return {
+            key for key, prior in self.items() if isinstance(prior, Cosmological)
+        }
+
+    @property
+    def is_cosmological(self):
+        """Return True if any of the priors are cosmological."""
+        if self._cosmological_priors:
+            return True
+        else:
+            return False
+
+    @property
+    def cosmology(self):
+        """The cosmology used in the priors."""
+        if self.is_cosmological:
+            return self[self._cosmological_priors[0]].cosmology
+        else:
+            return None
+
+    def check_valid_cosmology(self, error=True, warning=False):
+        """Check that all cosmological priors use the same cosmology.
+
+        .. versionadded:: 2.5.0
+
+        Parameters
+        ==========
+        error: bool
+            Whether to raise a ValueError on failure.
+        warning: bool
+            Whether to log a warning on failure.
+
+        Returns
+        =======
+        bool: whether the cosmological priors are valid.
+
+        Raises
+        ======
+        ValueError: if error is True and the cosmological priors are invalid.
+        """
+        cosmological_priors = self._cosmological_priors
+        if not cosmological_priors:
+            return True
+
+        from astropy.cosmology import cosmology_equal
+
+        cosmologies = [self[key].cosmology for key in self._cosmological_priors]
+        if all(cosmology_equal(cosmologies[0], c, allow_equivalent=True) for c in cosmologies[1:]):
+            return True
+
+        message = (
+            "All cosmological priors must use the same cosmology. "
+            f"Found: {cosmologies}"
+        )
+        if warning:
+            logger.warning(message)
+            return False
+        if error:
+            raise ValueError(message)
+
     def validate_prior(self, duration, minimum_frequency, N=1000, error=True, warning=False):
         """ Validate the prior is suitable for use
 

--- a/test/gw/prior_test.py
+++ b/test/gw/prior_test.py
@@ -174,11 +174,11 @@ class TestBBHPriorDict(unittest.TestCase):
         self.bbh_prior_dict["luminosity_distance"] = bilby.gw.prior.UniformComovingVolume(
             minimum=10, maximum=10000, name="luminosity_distance"
         )
-        self.assertTrue(self.bbh_prior_dict.is_cosmological())
+        self.assertTrue(self.bbh_prior_dict.is_cosmological)
 
     def test_is_cosmological_false(self):
         del self.bbh_prior_dict["luminosity_distance"]
-        self.assertFalse(self.bbh_prior_dict.is_cosmological())
+        self.assertFalse(self.bbh_prior_dict.is_cosmological)
 
     def test_check_valid_cosmology(self):
         self.bbh_prior_dict["luminosity_distance"] = bilby.gw.prior.UniformComovingVolume(

--- a/test/gw/prior_test.py
+++ b/test/gw/prior_test.py
@@ -170,6 +170,44 @@ class TestBBHPriorDict(unittest.TestCase):
         )
         self.assertFalse(self.bbh_prior_dict.test_has_redundant_keys())
 
+    def test_is_cosmological_true(self):
+        self.bbh_prior_dict["luminosity_distance"] = bilby.gw.prior.UniformComovingVolume(
+            minimum=10, maximum=10000, name="luminosity_distance"
+        )
+        self.assertTrue(self.bbh_prior_dict.is_cosmological())
+    
+    def test_is_cosmological_false(self):
+        del self.bbh_prior_dict["luminosity_distance"]
+        self.assertFalse(self.bbh_prior_dict.is_cosmological())
+
+    def test_check_valid_cosmology(self):
+        self.bbh_prior_dict["luminosity_distance"] = bilby.gw.prior.UniformComovingVolume(
+            minimum=10, maximum=10000, name="luminosity_distance"
+        )
+        self.assertTrue(self.bbh_prior_dict.check_valid_cosmology())
+
+    def test_check_valid_cosmology_raises_error(self):
+        self.bbh_prior_dict["luminosity_distance"] = bilby.gw.prior.UniformComovingVolume(
+            minimum=10, maximum=10000, name="luminosity_distance", cosmology="Planck15",
+        )
+        self.bbh_prior_dict["redshift"] = bilby.gw.prior.UniformComovingVolume(
+            minimum=0.1, maximum=1, name="redshift", cosmology="Planck15_LAL",
+        )
+        self.assertEqual(
+            self.bbh_prior_dict._cosmological_priors,
+            ["luminosity_distance", "redshift"],
+        )
+        self.assertRaises(ValueError, self.bbh_prior_dict.check_valid_cosmology)
+
+    def test_cosmology(self):
+        self.bbh_prior_dict["luminosity_distance"] = bilby.gw.prior.UniformComovingVolume(
+            minimum=10, maximum=10000, name="luminosity_distance"
+        )
+        self.assertEqual(
+            self.bbh_prior_dict.cosmology,
+            self.bbh_prior_dict["luminosity_distance"].cosmology,
+        )
+
     def test_pickle_prior(self):
         priors = dict(
             chirp_mass=bilby.core.prior.Uniform(10, 20),

--- a/test/gw/prior_test.py
+++ b/test/gw/prior_test.py
@@ -175,7 +175,7 @@ class TestBBHPriorDict(unittest.TestCase):
             minimum=10, maximum=10000, name="luminosity_distance"
         )
         self.assertTrue(self.bbh_prior_dict.is_cosmological())
-    
+
     def test_is_cosmological_false(self):
         del self.bbh_prior_dict["luminosity_distance"]
         self.assertFalse(self.bbh_prior_dict.is_cosmological())


### PR DESCRIPTION
Add attributes and a method that allow the user to check if a `CBCPriorDict` contains any cosmological priors and check they use the same cosmology.

This should simplify adding a cosmology to `bilby_pipe` as it will allows to easily check the priors are valid and then pull the cosmology.