### PR TITLE
[BUG]: fixing dtypes being changed in plot_interferometer_waveform_posterior

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,6 +16,7 @@ Bruce Edelman
 Carl-Johan Haster
 Cecilio Garcia-Quiros
 Charlie Hoy
+Cheng Foo
 Chentao Yang
 Christopher Philip Luke Berry
 Christos Karathanasis

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -496,8 +496,8 @@ class CompactBinaryCoalescenceResult(CoreResult):
 
         fd_waveforms = list()
         td_waveforms = list()
-        for _, params in samples.iterrows():
-            params = dict(params)
+        for params in samples.itertuples(index=False):
+            params = dict(params._asdict())
             wf_pols = waveform_generator.frequency_domain_strain(params)
             fd_waveform = interferometer.get_detector_response(wf_pols, params)
             fd_waveforms.append(fd_waveform[frequency_idxs])

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -496,8 +496,7 @@ class CompactBinaryCoalescenceResult(CoreResult):
 
         fd_waveforms = list()
         td_waveforms = list()
-        for params in samples.itertuples(index=False):
-            params = dict(params._asdict())
+        for params in samples.to_dict(orient="records"):
             wf_pols = waveform_generator.frequency_domain_strain(params)
             fd_waveform = interferometer.get_detector_response(wf_pols, params)
             fd_waveforms.append(fd_waveform[frequency_idxs])


### PR DESCRIPTION
Fixing a small bug in CBCResult. plot_interferometer_waveform_posterior, where the pandas.posterior.iterrows() function sometimes changes dtype of input (e.g. from float to complex), leading to some errors later down the line. Replaced with a very similar method itertuples which preserves dtypes of inputs.
