### PR TITLE
MAINT: dynesty - reduce number of calls to add_live_points

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -667,7 +667,7 @@ class Dynesty(NestedSampler):
 
     def finalize_sampler_kwargs(self, sampler_kwargs):
         sampler_kwargs["maxcall"] = self.n_check_point
-        sampler_kwargs["add_live"] = True
+        sampler_kwargs["add_live"] = False
 
     def _run_external_sampler_with_checkpointing(self):
         """
@@ -675,8 +675,11 @@ class Dynesty(NestedSampler):
         periods of time (less than the checkpoint time) and if sufficient
         time has passed, write a checkpoint before continuing. To get the most
         informative checkpoint plots, the current live points are added to the
-        chain of nested samples within dynesty and have to be removed before
-        restarting the sampler.
+        chain of nested samples before making the plots and have to be removed
+        before restarting the sampler. We previously used the dynesty internal
+        version of this, but this is unsafe as dynesty is not capable of
+        determining if adding the live points was interrupted and so we want to
+        minimize the number of times this is done.
         """
 
         logger.debug("Running sampler with checkpointing")
@@ -691,8 +694,7 @@ class Dynesty(NestedSampler):
         )
         while True:
             self.finalize_sampler_kwargs(sampler_kwargs)
-            if getattr(self.sampler, "added_live", False):
-                self.sampler._remove_live_points()
+            self._remove_live()
             self.sampler.run_nested(**sampler_kwargs)
             if self.sampler.ncall == old_ncall:
                 break
@@ -706,14 +708,25 @@ class Dynesty(NestedSampler):
                 ).total_seconds()
             if last_checkpoint_s > self.check_point_delta_t:
                 self.write_current_state()
+                self._add_live()
                 self.plot_current_state()
-        if getattr(self.sampler, "added_live", False):
-            self.sampler._remove_live_points()
-
+                self._remove_live()
+        
+        self._remove_live()
+        sampler_kwargs["add_live"] = True
         self.sampler.run_nested(**sampler_kwargs)
         self.write_current_state()
         self.plot_current_state()
         return self.sampler.results
+
+    def _add_live(self):
+        if not self.sampler.added_live:
+            for _ in self.sampler.add_live_points():
+                pass
+
+    def _remove_live(self):
+        if self.sampler.added_live:
+            self.sampler._remove_live_points()
 
     def _remove_checkpoint(self):
         """Remove checkpointed state"""
@@ -774,8 +787,8 @@ class Dynesty(NestedSampler):
                         )
                 del sampler.versions
                 self.sampler = sampler
-                if getattr(self.sampler, "added_live", False) and continuing:
-                    self.sampler._remove_live_points()
+                if continuing:
+                    self._remove_live()
                 self.sampler.nqueue = -1
                 self.start_time = self.sampler.kwargs.pop("start_time")
                 self.sampling_time = self.sampler.kwargs.pop("sampling_time")


### PR DESCRIPTION
A bug in dynesty (https://github.com/joshspeagle/dynesty/issues/490) means that the chain can be corrupted if we write a checkpoint after catching an interrupt.

Currently, we call the unsafe method (add_live_points) more frequently than we need to. This PR makes it so that we only call this when making trace plots and after writing our main checkpoint file. This should reduce the number of calls drastically and practically eliminate our exposure to the issue.

Longer term, we may want to think about moving away from writing a new checkpoint file when exiting and rely on previously written checkpoints as pointed out in the linked issue, writing a checkpoint on exit will always be fundamentally unsafe, even if it can be made practically safe.