### PR TITLE
ENH: add global meta data

### DIFF
--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -7,6 +7,7 @@ from ..utils import (
     command_line_args,
     env_package_list,
     get_entry_points,
+    global_meta_data,
     loaded_modules_dict,
     logger,
 )
@@ -251,6 +252,7 @@ def run_sampler(
     meta_data["likelihood"] = likelihood.meta_data
     meta_data["loaded_modules"] = loaded_modules_dict()
     meta_data["environment_packages"] = env_package_list(as_dataframe=True)
+    meta_data["global_meta_data"] = global_meta_data
 
     if command_line_args.bilby_zero_likelihood_mode:
         from bilby.core.likelihood import ZeroLikelihood

--- a/bilby/core/utils/__init__.py
+++ b/bilby/core/utils/__init__.py
@@ -10,6 +10,7 @@ from .entry_points import *
 from .introspection import *
 from .io import *
 from .log import *
+from .meta_data import *
 from .plotting import *
 from .samples import *
 from .series import *

--- a/bilby/core/utils/io.py
+++ b/bilby/core/utils/io.py
@@ -1,3 +1,4 @@
+from collections import UserDict, UserList
 import datetime
 import inspect
 import json
@@ -43,6 +44,8 @@ class BilbyJsonEncoder(json.JSONEncoder):
                 "__name__": obj.__class__.__name__,
                 "kwargs": dict(obj.get_instantiation_dict()),
             }
+        if isinstance(obj, (UserDict, UserList)):
+            return obj.data
         if isinstance(obj, ProposalCycle):
             return str(obj)
         try:
@@ -463,6 +466,8 @@ def encode_for_hdf5(key, item):
         )
     elif isinstance(item, dict):
         output = item.copy()
+    elif isinstance(item, (UserDict, UserList)):
+        output = item.data
     elif isinstance(item, tuple):
         output = {str(ii): elem for ii, elem in enumerate(item)}
     elif isinstance(item, datetime.timedelta):

--- a/bilby/core/utils/meta_data.py
+++ b/bilby/core/utils/meta_data.py
@@ -1,7 +1,10 @@
+from collections import UserDict
+
 from . import random
+from .log import logger
 
 
-class GlobalMetaData(dict):
+class GlobalMetaData(UserDict):
     """A class to store global meta data.
 
     This class is a singleton, meaning that only one instance can exist at a time.
@@ -9,8 +12,15 @@ class GlobalMetaData(dict):
 
     _instance = None
 
-    def add_to_meta_data(self, key, value):
-        self[key] = value
+    def __setitem__(self, key, item):
+        if key in self:
+            logger.debug(
+                f"Overwriting meta data key {key} with value {item}. "
+                f"Old value was {self[key]}"
+            )
+        else:
+            logger.debug(f"Setting meta data key {key} with value {item}")
+        return super().__setitem__(key, item)
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/bilby/core/utils/meta_data.py
+++ b/bilby/core/utils/meta_data.py
@@ -1,0 +1,25 @@
+from collections import UserDict
+
+from . import random
+
+
+class GlobalMetaData(UserDict):
+    """A class to store global meta data.
+
+    This class is a singleton, meaning that only one instance can exist at a time.
+    """
+
+    _instance = None
+
+    def add_to_meta_data(self, key, value):
+        self[key] = value
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+
+global_meta_data = GlobalMetaData({
+    "rng": random.rng
+})

--- a/bilby/core/utils/meta_data.py
+++ b/bilby/core/utils/meta_data.py
@@ -1,9 +1,7 @@
-from collections import UserDict
-
 from . import random
 
 
-class GlobalMetaData(UserDict):
+class GlobalMetaData(dict):
     """A class to store global meta data.
 
     This class is a singleton, meaning that only one instance can exist at a time.

--- a/bilby/core/utils/random.py
+++ b/bilby/core/utils/random.py
@@ -14,8 +14,8 @@ def seed(seed):
     from .meta_data import global_meta_data
 
     Generator.rng = default_rng(seed)
-    global_meta_data.add_to_meta_data("rng", Generator.rng)
-    global_meta_data.add_to_meta_data("seed", seed)
+    global_meta_data["rng"] = Generator.rng
+    global_meta_data["seed"] = seed
 
 
 def generate_seeds(nseeds):

--- a/bilby/core/utils/random.py
+++ b/bilby/core/utils/random.py
@@ -11,7 +11,10 @@ class Generator:
 
 
 def seed(seed):
+    from .meta_data import global_meta_data
+
     Generator.rng = default_rng(seed)
+    global_meta_data.add_to_meta_data("rng", Generator.rng)
 
 
 def generate_seeds(nseeds):

--- a/bilby/core/utils/random.py
+++ b/bilby/core/utils/random.py
@@ -15,6 +15,7 @@ def seed(seed):
 
     Generator.rng = default_rng(seed)
     global_meta_data.add_to_meta_data("rng", Generator.rng)
+    global_meta_data.add_to_meta_data("seed", seed)
 
 
 def generate_seeds(nseeds):

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -13,7 +13,7 @@ def _set_default_cosmology():
     if DEFAULT_COSMOLOGY is None:
         DEFAULT_COSMOLOGY = cosmo.Planck15
         COSMOLOGY = [DEFAULT_COSMOLOGY, DEFAULT_COSMOLOGY.name]
-        global_meta_data.add_to_meta_data("cosmology", COSMOLOGY)
+        global_meta_data.add_to_meta_data("cosmology", COSMOLOGY[0])
 
 
 def get_available_cosmologies():

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -91,12 +91,14 @@ def set_cosmology(cosmology=None):
             Dictionary with arguments required to instantiate the cosmology
             class.
     """
+    from ..core.utils.meta_data import global_meta_data
     cosmology = get_cosmology(cosmology)
     COSMOLOGY[0] = cosmology
     if cosmology.name is not None:
         COSMOLOGY[1] = cosmology.name
     else:
         COSMOLOGY[1] = repr(cosmology)
+    global_meta_data.add_to_meta_data("cosmology", cosmology)
 
 
 def z_at_value(func, fval, **kwargs):

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -13,7 +13,7 @@ def _set_default_cosmology():
     if DEFAULT_COSMOLOGY is None:
         DEFAULT_COSMOLOGY = cosmo.Planck15
         COSMOLOGY = [DEFAULT_COSMOLOGY, DEFAULT_COSMOLOGY.name]
-        global_meta_data.add_to_meta_data("cosmology", COSMOLOGY[0])
+        global_meta_data["cosmology"] = COSMOLOGY[0]
 
 
 def get_available_cosmologies():
@@ -98,7 +98,7 @@ def set_cosmology(cosmology=None):
         COSMOLOGY[1] = cosmology.name
     else:
         COSMOLOGY[1] = repr(cosmology)
-    global_meta_data.add_to_meta_data("cosmology", cosmology)
+    global_meta_data["cosmology"] = cosmology
 
 
 def z_at_value(func, fval, **kwargs):

--- a/bilby/gw/cosmology.py
+++ b/bilby/gw/cosmology.py
@@ -8,10 +8,12 @@ COSMOLOGY = [None, str(None)]
 
 def _set_default_cosmology():
     from astropy import cosmology as cosmo
+    from ..core.utils.meta_data import global_meta_data
     global DEFAULT_COSMOLOGY, COSMOLOGY
     if DEFAULT_COSMOLOGY is None:
         DEFAULT_COSMOLOGY = cosmo.Planck15
         COSMOLOGY = [DEFAULT_COSMOLOGY, DEFAULT_COSMOLOGY.name]
+        global_meta_data.add_to_meta_data("cosmology", COSMOLOGY)
 
 
 def get_available_cosmologies():

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -23,7 +23,9 @@ class CompactBinaryCoalescenceResult(CoreResult):
         if "meta_data" not in kwargs:
             kwargs["meta_data"] = dict()
         if "global_meta_data" not in kwargs:
-            kwargs["meta_data"]["global_meta_data"] = dict()
+            from ..core.utils.meta_data import global_meta_data
+
+            kwargs["meta_data"]["global_meta_data"] = global_meta_data
         # Ensure cosmology is always stored in the meta_data
         if "cosmology" not in kwargs["meta_data"]["global_meta_data"]:
             from .cosmology import get_cosmology

--- a/test/core/utils_test.py
+++ b/test/core/utils_test.py
@@ -482,8 +482,8 @@ class TestGlobalMetaData(unittest.TestCase):
         bilby.gw.cosmology.DEFAULT_COSMOLOGY = None
         bilby.gw.cosmology.COSMOLOGY = [None, str(None)]
 
-    def test_add_to_meta_data(self):
-        global_meta_data.add_to_meta_data("test", 123)
+    def test_set_item(self):
+        global_meta_data["test"] = 123
         self.assertEqual(global_meta_data["test"], 123)
 
     def test_set_rng(self):

--- a/test/core/utils_test.py
+++ b/test/core/utils_test.py
@@ -12,6 +12,7 @@ import pytest
 
 import bilby
 from bilby.core import utils
+from bilby.core.utils import global_meta_data
 
 
 class TestConstants(unittest.TestCase):
@@ -465,6 +466,34 @@ class TestSavingNumpyRandomGenerator(unittest.TestCase):
             data = dill.load(file)
         b = data["rng"].random()
         self.assertEqual(a, b)
+
+
+class TestGlobalMetaData(unittest.TestCase):
+
+    def setUp(self):
+        global_meta_data.clear()
+        global_meta_data["rng"] = bilby.core.utils.random.rng
+        bilby.gw.cosmology.DEFAULT_COSMOLOGY = None
+        bilby.gw.cosmology.COSMOLOGY = [None, str(None)]
+
+    def tearDown(self):
+        global_meta_data.clear()
+        global_meta_data["rng"] = bilby.core.utils.random.rng
+        bilby.gw.cosmology.DEFAULT_COSMOLOGY = None
+        bilby.gw.cosmology.COSMOLOGY = [None, str(None)]
+
+    def test_add_to_meta_data(self):
+        global_meta_data.add_to_meta_data("test", 123)
+        self.assertEqual(global_meta_data["test"], 123)
+
+    def test_set_rng(self):
+        bilby.core.utils.random.seed(1234)
+        self.assertTrue(global_meta_data["rng"] is bilby.core.utils.random.rng)
+        self.assertEqual(global_meta_data["seed"], 1234)
+
+    def test_set_cosmology(self):
+        bilby.gw.cosmology.set_cosmology("Planck15_LAL")
+        self.assertTrue(global_meta_data["cosmology"] is bilby.gw.cosmology.COSMOLOGY[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on the discussion in https://github.com/bilby-dev/bilby/pull/867, I've made a start on a possible implementation of a global meta data object.

For now, it's just a singleton dictionary that, by default, tracks the `rng`. Things like the `cosmology` can then be added when they're set.

**Motivation**

This change makes it easier to keep track of any global variables and allows us to ensure they're saved in the result file after running a sampler.

**Changes** (updated 27/01/25)

- Add a new `meta_data` submodule and `GlobalMetaData` class
- Add functions for encoding/decoding numpy random generators
- Add test for saving generators
- Extend `seed`, `set_cosmology` and `_set_default_cosmology` to update the global meta data when called.
- Add functions for encoding `UserDict` and `UserList` subclasses. These rely on the fact both classes have a `data` attribute, see [the Python docs](https://docs.python.org/3/library/collections.html#userdict-objects)

**Testing**

These changes are mostly covered by the existing tests save result files, but I added a test for the encoding/decoding change and for the global meta data class.