### PR TITLE
TST: add `requires_roqs` mark to tests that use ROQs

### DIFF
--- a/test/gw/likelihood/marginalization_test.py
+++ b/test/gw/likelihood/marginalization_test.py
@@ -157,6 +157,7 @@ class TestMarginalizedLikelihood(unittest.TestCase):
             bilby.run_sampler(like, new_prior)
 
 
+@pytest.mark.requires_roqs
 class TestMarginalizations(unittest.TestCase):
     """
     Test all marginalised likelihoods matches brute force version.

--- a/test/gw/source_test.py
+++ b/test/gw/source_test.py
@@ -298,6 +298,7 @@ class TestEccentricLalBBH(unittest.TestCase):
             )
 
 
+@pytest.mark.requires_roqs
 class TestROQBBH(unittest.TestCase):
     def setUp(self):
         roq_dir = "/roq_basis"


### PR DESCRIPTION
I realised that some of the tests that use ROQs aren't marked with the `required_roqs` mark. This means they aren't skipped when running

```bash
pytest --skip-roqs
```