### PR TITLE
FEAT: add gwsignal waveform generator

### DIFF
--- a/bilby/gw/source.py
+++ b/bilby/gw/source.py
@@ -86,6 +86,11 @@ def gwsignal_binary_black_hole(frequency_array, mass_1, mass_2, luminosity_dista
     This version is only intended to be used with `SEOBNRv5HM` and `SEOBNRv5PHM` and
     does not have full functionality for other waveform models.
     """
+    logger.warning(
+        "bilby.gw.source.gwsignal_binary_black_hole is deprecated and will be removed "
+        "in a future release, use bilby.gw.waveform_generator.GWSignalWaveformGenerator"
+        " instead."
+    )
 
     from lalsimulation.gwsignal import GenerateFDWaveform
     from lalsimulation.gwsignal.models import gwsignal_get_waveform_generator


### PR DESCRIPTION
@raffienficiaud this is a quick version of how I had envisioned an extension to the gwsignal support. It doesn't require explicit enumeration of all of the different kinds of source models, users can just do something like

```python
import bilby

priors = bilby.gw.prior.BBHPriorDict()
priors["eccentricity"] = bilby.core.prior.Uniform(0, 1)
priors["mean_per_ano"] = 0.0
del priors["a_1"], priors["a_2"], priors["tilt_1"], priors["tilt_2"], priors["phi_jl"], priors["phi_12"]

wfg = bilby.gw.waveform_generator.GWSignalWaveformGenerator(
    waveform_arguments=dict(waveform_approximant="EccentricFD"),
    duration=4,
    sampling_frequency=1024,
    eccentric=True,
    spinning=False,
)

wfg.frequency_domain_strain(priors.sample())
```

I'm sure there are improvements that could be made to the interface, but I'm hopeful that something like this can be fairly transparent to the underlying `gwsignal` capabilities and ideally not need a lot of modification as more features are added to that. Since you have more experience with `gwsignal` I'd be glad to hear any thoughts.

Also @adivijaykumar @antoniramosbuades and @mj-will 