### PR TITLE
MAINT: avoid call to deprecated `scipy.special.btdtr` and `scipy.special.btdtri` functions

### DIFF
--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -1,7 +1,18 @@
 import numpy as np
 from scipy.special import erfinv
-from scipy.special._ufuncs import xlogy, erf, log1p, stdtrit, gammaln, stdtr, \
-    btdtri, betaln, btdtr, gammaincinv, gammainc
+from scipy.special._ufuncs import (
+    xlogy,
+    erf,
+    log1p,
+    stdtrit,
+    gammaln,
+    stdtr,
+    betaln,
+    betaincinv,
+    btdtr,
+    gammaincinv,
+    gammainc,
+)
 
 from .base import Prior
 from ..utils import logger
@@ -967,7 +978,7 @@ class Beta(Prior):
 
         This maps to the inverse CDF. This has been analytically solved for this case.
         """
-        return btdtri(self.alpha, self.beta, val) * (self.maximum - self.minimum) + self.minimum
+        return betaincinv(self.alpha, self.beta, val) * (self.maximum - self.minimum) + self.minimum
 
     def prob(self, val):
         """Return the prior probability of val.

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -8,8 +8,8 @@ from scipy.special._ufuncs import (
     gammaln,
     stdtr,
     betaln,
+    betainc,
     betaincinv,
-    btdtr,
     gammaincinv,
     gammainc,
 )
@@ -1025,10 +1025,12 @@ class Beta(Prior):
             elif val < self.minimum:
                 return 0.
             else:
-                return btdtr(self.alpha, self.beta,
-                             (val - self.minimum) / (self.maximum - self.minimum))
+                return betainc(
+                    self.alpha, self.beta,
+                    (val - self.minimum) / (self.maximum - self.minimum)
+                )
         else:
-            _cdf = np.nan_to_num(btdtr(self.alpha, self.beta,
+            _cdf = np.nan_to_num(betainc(self.alpha, self.beta,
                                  (val - self.minimum) / (self.maximum - self.minimum)))
             _cdf[val < self.minimum] = 0.
             _cdf[val > self.maximum] = 1.

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -1,8 +1,8 @@
 import numpy as np
-from scipy.special import erfinv
-from scipy.special._ufuncs import (
+from scipy.special import (
     xlogy,
     erf,
+    erfinv,
     log1p,
     stdtrit,
     gammaln,


### PR DESCRIPTION
`scipy.special.btdtr` and `scipy.special.btdtri` are deprecated and were removed in `scipy` 1.14.0 (see the docs [here](https://docs.scipy.org/doc/scipy-1.13.0/reference/generated/scipy.special.btdtri.html) and [here](https://docs.scipy.org/doc/scipy-1.13.0/reference/generated/scipy.special.btdtr.html#scipy.special.btdtr)). The PR replaces the import and call with `betainc` and `betaincinv` which are equivalent.

**Motivation**

Since this function has been removed, we have to change the code if we are going to support `scipy` >= 1.14.0.

The CI was failing due to this import. See e.g. https://github.com/bilby-dev/bilby/actions/runs/12650850335

**Testing**

I've run the tests locally and they pass.

**Other notes**

I also reformatted the imports to follow the formatting used by `black`