### PR TITLE
CI: temporarily require matplotlib <3.10

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install package
       run: |
+        # FIXME: Remove this line when gwpy supports matplotlib 3.10
+        conda install -c conda-forge "matplotlib<3.10"
         python -m pip install .
         conda list --show-channel-urls
     # - name: Run precommits


### PR DESCRIPTION
Temporarily force `matplotlib` < 3.10 in the CI.

**Motivation**

`gwpy` is currently incompatible with `matplotlib` 3.10 (see https://gitlab.com/gwpy/gwpy/-/issues/1786) and this is causing the CI to fail; see https://github.com/bilby-dev/bilby/pull/884

**Details**

Rather than modify the containers, I've just forced `conda` to install a lower version of `matplotlib` before installing `bilby`

**Other notes**

This PR should be reverted once a new release of `gwpy` has been made.