### PR TITLE
TST: remove calls to deprecated `numpy.alltrue` function

### DIFF
--- a/test/gw/detector/calibration_test.py
+++ b/test/gw/detector/calibration_test.py
@@ -22,7 +22,7 @@ class TestBaseClass(unittest.TestCase):
     def test_calibration_factor(self):
         frequency_array = np.linspace(20, 1024, 1000)
         cal_factor = self.model.get_calibration_factor(frequency_array)
-        assert np.alltrue(cal_factor.real == np.ones_like(frequency_array))
+        assert np.all(cal_factor.real == np.ones_like(frequency_array))
 
 
 class TestCubicSpline(unittest.TestCase):
@@ -56,7 +56,7 @@ class TestCubicSpline(unittest.TestCase):
         cal_factor = self.model.get_calibration_factor(
             frequency_array, **self.parameters
         )
-        assert np.alltrue(cal_factor.real == np.ones_like(frequency_array))
+        assert np.all(cal_factor.real == np.ones_like(frequency_array))
 
     def test_repr(self):
         expected = "CubicSpline(prefix='{}', minimum_frequency={}, maximum_frequency={}, n_points={})".format(


### PR DESCRIPTION
Remove calls to `numpy.alltrue` in the test suite.

This function was deprecated before numpy 2.0 as then removed in 2.0. This causes the test suite to fail if using numpy 2.0.