### PR TITLE
CI: specify python version and activate env

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CONDA_PATH: /opt/conda/
+
 jobs:
   build:
 
@@ -41,7 +44,7 @@ jobs:
     - name: Install package
       run: |
         # activate env so that conda list shows the correct environment
-        source /opt/conda/bin/activate python${{ matrix.python.short-version }}
+        source $CONDA_PATH/bin/activate python${{ matrix.python.short-version }}
         # FIXME: Remove this line when gwpy supports matplotlib 3.10
         conda install -c conda-forge "matplotlib<3.10"
         python -m pip install .

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Activate environment
       run: |
-        conda activate python${{ matrix.python.short-version }}
+        source activate python${{ matrix.python.short-version }}
     - name: Install package
       run: |
         # FIXME: Remove this line when gwpy supports matplotlib 3.10

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Activate environment
       run: |
         source activate python${{ matrix.python.short-version }}
+      shell: bash
     - name: Install package
       run: |
         # FIXME: Remove this line when gwpy supports matplotlib 3.10

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Activate environment
       run: |
-        source activate python${{ matrix.python.short-version }}
+        source /opt/conda/bin/activate python${{ matrix.python.short-version }}
+        conda list --show-channel-urls
       shell: bash
     - name: Install package
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,13 +19,28 @@ concurrency:
 jobs:
   build:
 
+    name: ${{ matrix.python.name }} unit tests
     runs-on: ubuntu-latest
-    container: ghcr.io/bilby-dev/bilby-python311:latest
+    container: ghcr.io/bilby-dev/bilby-python${{ matrix.python.short-version }}:latest
     strategy:
       fail-fast: false
+      matrix:
+        python:
+          - name: Python 3.10
+            version: 3.10
+            short-version: 310
+          - name: Python 3.11
+            version: 3.11
+            short-version: 311
+          - name: Python 3.12
+            version: 3.12
+            short-version: 312
 
     steps:
     - uses: actions/checkout@v3
+    - name: Activate environment
+      run: |
+        conda activate python${{ matrix.python.short-version }}
     - name: Install package
       run: |
         # FIXME: Remove this line when gwpy supports matplotlib 3.10

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,17 +38,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Activate environment
-      run: |
-        source /opt/conda/bin/activate python${{ matrix.python.short-version }}
-        conda list --show-channel-urls
-      shell: bash
     - name: Install package
       run: |
+        # activate env so that conda list shows the correct environment
+        source /opt/conda/bin/activate python${{ matrix.python.short-version }}
         # FIXME: Remove this line when gwpy supports matplotlib 3.10
         conda install -c conda-forge "matplotlib<3.10"
         python -m pip install .
         conda list --show-channel-urls
+      shell: bash
     # - name: Run precommits
     #   run: |
     #     pre-commit run --all-files --verbose --show-diff-on-failure


### PR DESCRIPTION
Run unit tests of different python versions and activate conda environment.

**Motivation**

While try to fix the CI issues in https://github.com/bilby-dev/bilby/pull/884, I realised that the conda environment created in the containers is not being activated. This mean that an `conda` commands are not being run in the right env. This can be fixed by activating the environment. Since the environments are named `python<version without dot>` e.g. `python311`, I thought this would a good moment to add different Python versions into the CI.

**Changes**

I've added a `matrix` entry to the `stratergy` section of the unit test CI. This contains the different Python versions along with the short version name (e.g. 311) which is needed to fetch the container.