### PR TITLE
TST: relax tolerance for prior test with cosmo parameters

### DIFF
--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -625,7 +625,7 @@ class TestLoadPriorWithCosmologicalParameters(unittest.TestCase):
 
         dl = 1000.0
         ln_prob = prior_dict["luminosity_distance"].ln_prob(dl)
-        self.assertEqual(ln_prob, -9.360343006800193)
+        self.assertAlmostEqual(ln_prob, -9.360343006800193, 12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Relax the tolerance for the prior test that uses cosmology.

**Motivation**

Due to, I assume, an updated dependency, the exact value returned by `ln_prob` in this test has changed very slightly. This has caused the tests to fail with the following error:

```
FAILED test/core/prior/dict_test.py::TestLoadPriorWithCosmologicalParameters::test_load - AssertionError: -9.360343006800319 != -9.360343006800193
```
see for example https://github.com/bilby-dev/bilby/actions/runs/12686406298/job/35358676377?pr=884.

**Changes**

In order to avoid this and get the CI passing again, I've added a tolerance to the test so that it passes.

**Testing**

I tested this with a new environment that included the fix in https://github.com/bilby-dev/bilby/pull/884 and the tests now pass.

**Other notes**

This PR should probably be merged after https://github.com/bilby-dev/bilby/pull/884