### PR TITLE
STY: fix style error

### DIFF
--- a/bilby/bilby_mcmc/sampler.py
+++ b/bilby/bilby_mcmc/sampler.py
@@ -530,7 +530,7 @@ class Bilby_MCMC(MCMCSampler):
                 else:
                     ratio = "-"
                 logger.info(
-                    f"Temp:{ii}<->{ii+1}|"  # noqa: E226
+                    f"Temp:{ii}<->{ii + 1}|"
                     f"beta={beta:0.4g}|"
                     f"hot-samp={sampler.nsamples}|"
                     f"swap={ratio}|"

--- a/bilby/bilby_mcmc/sampler.py
+++ b/bilby/bilby_mcmc/sampler.py
@@ -530,7 +530,7 @@ class Bilby_MCMC(MCMCSampler):
                 else:
                     ratio = "-"
                 logger.info(
-                    f"Temp:{ii}<->{ii+1}|"
+                    f"Temp:{ii}<->{ii+1}|"  # noqa: E226
                     f"beta={beta:0.4g}|"
                     f"hot-samp={sampler.nsamples}|"
                     f"swap={ratio}|"


### PR DESCRIPTION
Ignore the specific error relating to missing whitespace (E226) in the logging out for bilby_MCMC.

**Motivation**

After an update to various dependencies, `f"Temp:{ii}<->{ii+1}|"` was trigger a `flake8` error (226) because of missing whitespace around the operator(s) (not sure if it's a specific operator or all of them). ~~Since these operators are actually just part of the logging statement, this error can be ignored.~~

Colm pointed out the issue was the `i+1` rather than the string.

See e.g. the CI here: https://github.com/bilby-dev/bilby/actions/runs/12686391271/job/35358629525

**Changes**

Fix the fomatting issue,

**Other details**

Closes #889 