### PR TITLE
CI: remove constraint on matplotlib version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,8 +45,6 @@ jobs:
       run: |
         # activate env so that conda list shows the correct environment
         source $CONDA_PATH/bin/activate python${{ matrix.python.short-version }}
-        # FIXME: Remove this line when gwpy supports matplotlib 3.10
-        conda install -c conda-forge "matplotlib<3.10"
         python -m pip install .
         conda list --show-channel-urls
       shell: bash


### PR DESCRIPTION
The issue that required this was fixed in gwpy 3.11, see https://gitlab.com/gwpy/gwpy/-/releases/v3.0.11.

I don't think we need to set a minimum version, but we'll see if the CI passes.