### PR TITLE
Fix unused waveform_kwargs warning with MB likelihood

### DIFF
--- a/bilby/gw/source.py
+++ b/bilby/gw/source.py
@@ -1091,6 +1091,8 @@ def _base_waveform_frequency_sequence(
     reference_frequency = waveform_kwargs.pop('reference_frequency')
     approximant = waveform_kwargs.pop('waveform_approximant')
     catch_waveform_errors = waveform_kwargs.pop('catch_waveform_errors')
+    _ = waveform_kwargs.pop("minimum_frequency", None)
+    _ = waveform_kwargs.pop("maximum_frequency", None)
 
     waveform_dictionary = set_waveform_dictionary(waveform_kwargs, lambda_1, lambda_2)
     approximant = lalsim_GetApproximantFromString(approximant)


### PR DESCRIPTION
Fixes https://github.com/bilby-dev/bilby/issues/905 by removing minimum_frequency and maximum_frequency from the waveform_kwargs in `_base_waveform_frequency_sequence`, even if they are not used.