### PR TITLE
Restore numerical_relativity_file kwarg

### DIFF
--- a/bilby/gw/source.py
+++ b/bilby/gw/source.py
@@ -517,7 +517,7 @@ def set_waveform_dictionary(waveform_kwargs, lambda_1=0, lambda_2=0):
     waveform_dictionary = waveform_kwargs.pop('lal_waveform_dictionary', CreateDict())
     waveform_kwargs["TidalLambda1"] = lambda_1
     waveform_kwargs["TidalLambda2"] = lambda_2
-    waveform_kwargs["NumRelData"] = waveform_kwargs.pop("numerical_relativity_data", None)
+    waveform_kwargs["NumRelData"] = waveform_kwargs.pop("numerical_relativity_file", None)
 
     for key in [
         "pn_spin_order", "pn_tidal_order", "pn_phase_order", "pn_amplitude_order"


### PR DESCRIPTION
Fixes https://github.com/bilby-dev/bilby/issues/908

Restores the waveform_kwarg to specify a numerical relativity file to be `numerical_relativity_file` rather than `numerical_relativity_data` in order to be consistent with [`bilby_pipe`](https://git.ligo.org/lscsoft/bilby_pipe/-/blob/master/bilby_pipe/input.py?ref_type=heads#L433).

Let me know if you prefer to use `numerical_relativity_data` instead and fix this in `bilby_pipe`.