### PR TITLE
BUG: fix incorrectly formatted raise statement

### DIFF
--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -1533,8 +1533,7 @@ class Result(object):
         if keys is None:
             keys = self.search_parameter_keys
         if self.injection_parameters is None:
-            raise (
-                TypeError,
+            raise TypeError(
                 "Result object has no 'injection_parameters'. "
                 "Cannot compute credible levels."
             )

--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -445,8 +445,11 @@ class TestResult(unittest.TestCase):
 
     def test_get_credible_levels_raises_error_if_no_injection_parameters(self):
         self.result.injection_parameters = None
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError) as error_context:
             self.result.get_all_injection_credible_levels()
+        self.assertTrue(
+            "Result object has no 'injection_parameters" in str(error_context.exception)
+        )
 
     def test_kde(self):
         kde = self.result.kde


### PR DESCRIPTION
The raise statement in `get_all_injection_credible_levels` is incorrectly formatted. This PR fixes the formatting.

This wasn't being caught by the existing test, since the error was also a `TypeError`:

```
TypeError: exceptions must derive from BaseException
```

so I've also updated the test to check error message itself.