### PR TITLE
ENH: add `num_interp` to `AlignedSpin` prior

### DIFF
--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -487,9 +487,18 @@ class AlignedSpin(Interped):
     analytic form of the PDF.
     """
 
-    def __init__(self, a_prior=Uniform(0, 1), z_prior=Uniform(-1, 1),
-                 name=None, latex_label=None, unit=None, boundary=None,
-                 minimum=np.nan, maximum=np.nan):
+    def __init__(
+        self,
+        a_prior=Uniform(0, 1),
+        z_prior=Uniform(-1, 1),
+        name=None,
+        latex_label=None,
+        unit=None,
+        boundary=None,
+        minimum=np.nan,
+        maximum=np.nan,
+        num_interp=None,
+    ):
         """
         Parameters
         ==========
@@ -500,6 +509,9 @@ class AlignedSpin(Interped):
         name: see superclass
         latex_label: see superclass
         unit: see superclass
+        num_interp: int
+            The number of points to use in the interpolation. Defaults to 100,000
+            for simple aligned priors and 10,000 for general priors.
         """
         self.a_prior = a_prior
         self.z_prior = z_prior
@@ -507,7 +519,8 @@ class AlignedSpin(Interped):
                       a_prior.minimum * z_prior.maximum)
         chi_max = a_prior.maximum * z_prior.maximum
         if self._is_simple_aligned_prior:
-            xx = np.linspace(chi_min, chi_max, 100000)
+            num_interp = 100_000 if num_interp is None else num_interp
+            xx = np.linspace(chi_min, chi_max, num_interp)
             yy = - np.log(np.abs(xx) / a_prior.maximum) / (2 * a_prior.maximum)
         else:
 
@@ -519,7 +532,8 @@ class AlignedSpin(Interped):
                 """
                 return a_prior.prob(aa) * z_prior.prob(chi / aa) / aa
 
-            xx = np.linspace(chi_min, chi_max, 10000)
+            num_interp = 10_000 if num_interp is None else num_interp
+            xx = np.linspace(chi_min, chi_max, num_interp)
             yy = [
                 quad(integrand, a_prior.minimum, a_prior.maximum, chi)[0]
                 for chi in xx

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -519,8 +519,8 @@ class AlignedSpin(Interped):
                       a_prior.minimum * z_prior.maximum)
         chi_max = a_prior.maximum * z_prior.maximum
         if self._is_simple_aligned_prior:
-            num_interp = 100_000 if num_interp is None else num_interp
-            xx = np.linspace(chi_min, chi_max, num_interp)
+            self.num_interp = 100_000 if num_interp is None else num_interp
+            xx = np.linspace(chi_min, chi_max, self.num_interp)
             yy = - np.log(np.abs(xx) / a_prior.maximum) / (2 * a_prior.maximum)
         else:
 
@@ -532,7 +532,7 @@ class AlignedSpin(Interped):
                 """
                 return a_prior.prob(aa) * z_prior.prob(chi / aa) / aa
 
-            num_interp = 10_000 if num_interp is None else num_interp
+            self.num_interp = 10_000 if num_interp is None else num_interp
             xx = np.linspace(chi_min, chi_max, num_interp)
             yy = [
                 quad(integrand, a_prior.minimum, a_prior.maximum, chi)[0]

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -533,7 +533,7 @@ class AlignedSpin(Interped):
                 return a_prior.prob(aa) * z_prior.prob(chi / aa) / aa
 
             self.num_interp = 10_000 if num_interp is None else num_interp
-            xx = np.linspace(chi_min, chi_max, num_interp)
+            xx = np.linspace(chi_min, chi_max, self.num_interp)
             yy = [
                 quad(integrand, a_prior.minimum, a_prior.maximum, chi)[0]
                 for chi in xx

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -92,6 +92,7 @@ class TestPriorClasses(unittest.TestCase):
                 z_prior=bilby.core.prior.Beta(alpha=2.0, beta=2.0, minimum=-1),
                 name="test",
                 unit="unit",
+                num_interp=1000,
             ),
             bilby.core.prior.MultivariateGaussian(dist=mvg, name="testa", unit="unit"),
             bilby.core.prior.MultivariateGaussian(dist=mvg, name="testb", unit="unit"),


### PR DESCRIPTION
https://github.com/bilby-dev/bilby/pull/849 added a new test to the `prior_test.py` but this test is currently taking ~1 hour total in the CI. To address this, I've added `num_interp` to the `AlignedSpin` prior. 

This allows us to speed up the test but allows the user to configure the interpolation. The defaults are the same (different for each case).

On my laptop, this reduced the time from ~20 minutes to ~ 2 minutes, but we'll see how the CI behaves.