### PR TITLE
MAINT: rework `GlobalMetaData` to inherit from `dict`

### DIFF
--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -503,7 +503,7 @@ class Result(object):
         self.prior_values = None
         self._kde = None
 
-        if string_to_boolean(os.getenv("BILBY_INCLUDE_GLOBAL_METADATA", "False")):
+        if not string_to_boolean(os.getenv("BILBY_INCLUDE_GLOBAL_META_DATA", "False")):
             gmd = self.meta_data.pop("global_meta_data", None)
             if gmd is not None:
                 logger.warning(
@@ -511,6 +511,8 @@ class Result(object):
                     "Use the `BILBY_INCLUDE_GLOBAL_METADATA` environment variable to include it. "
                     "This behaviour will be removed in a future release."
                 )
+        else:
+            logger.debug("Including global meta data in the result object.")
 
     _load_doctstring = """ Read in a saved .{format} data file
 

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -25,6 +25,7 @@ from .utils import (
     recursively_decode_bilby_json,
     safe_file_dump,
     random,
+    string_to_boolean,
 )
 from .prior import Prior, PriorDict, DeltaFunction, ConditionalDeltaFunction
 
@@ -501,6 +502,15 @@ class Result(object):
 
         self.prior_values = None
         self._kde = None
+
+        if string_to_boolean(os.getenv("BILBY_INCLUDE_GLOBAL_METADATA", "False")):
+            gmd = self.meta_data.pop("global_meta_data", None)
+            if gmd is not None:
+                logger.warning(
+                    "Global meta data was removed from the result object for compatibility. "
+                    "Use the `BILBY_INCLUDE_GLOBAL_METADATA` environment variable to include it. "
+                    "This behaviour will be removed in a future release."
+                )
 
     _load_doctstring = """ Read in a saved .{format} data file
 

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -506,7 +506,7 @@ class Result(object):
         if not string_to_boolean(os.getenv("BILBY_INCLUDE_GLOBAL_META_DATA", "False")):
             gmd = self.meta_data.pop("global_meta_data", None)
             if gmd is not None:
-                logger.warning(
+                logger.info(
                     "Global meta data was removed from the result object for compatibility. "
                     "Use the `BILBY_INCLUDE_GLOBAL_METADATA` environment variable to include it. "
                     "This behaviour will be removed in a future release."

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -509,7 +509,8 @@ class Result(object):
                 logger.info(
                     "Global meta data was removed from the result object for compatibility. "
                     "Use the `BILBY_INCLUDE_GLOBAL_METADATA` environment variable to include it. "
-                    "This behaviour will be removed in a future release."
+                    "This behaviour will be removed in a future release. "
+                    "For more details see: https://bilby-dev.github.io/bilby/faq.html#global-meta-data"
                 )
         else:
             logger.debug("Including global meta data in the result object.")

--- a/bilby/core/utils/__init__.py
+++ b/bilby/core/utils/__init__.py
@@ -7,6 +7,7 @@ from .conversion import *
 from .counter import *
 from .docs import *
 from .entry_points import *
+from .env import *
 from .introspection import *
 from .io import *
 from .log import *

--- a/bilby/core/utils/env.py
+++ b/bilby/core/utils/env.py
@@ -1,0 +1,16 @@
+
+
+def string_to_boolean(value):
+    """Convert a string to a boolean.
+
+    Supports True/False (case-insensitive), and 1/0.
+    """
+    value = value.strip().lower()
+    if value in ['true', '1']:
+        return True
+    elif value in ['false', '0']:
+        return False
+    else:
+        raise ValueError(
+            f"Invalid value for boolean: {value}"
+        )

--- a/bilby/core/utils/meta_data.py
+++ b/bilby/core/utils/meta_data.py
@@ -1,16 +1,23 @@
-from collections import UserDict
-
 from . import random
 from .log import logger
 
 
-class GlobalMetaData(UserDict):
+class GlobalMetaData(dict):
     """A class to store global meta data.
 
     This class is a singleton, meaning that only one instance can exist at a time.
     """
 
     _instance = None
+
+    def __init__(self, mapping=None, /, **kwargs):
+        if mapping is None:
+            mapping = {}
+        else:
+            mapping = dict(mapping)
+        mapping.update(kwargs)
+        for key, item in mapping.items():
+            self.__setitem__(key, item)
 
     def __setitem__(self, key, item):
         if key in self:
@@ -22,9 +29,18 @@ class GlobalMetaData(UserDict):
             logger.debug(f"Setting meta data key {key} with value {item}")
         return super().__setitem__(key, item)
 
+    def update(self, *args, **kwargs):
+        for key, item in dict(*args, **kwargs).items():
+            self.__setitem__(key, item)
+
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+        else:
+            logger.warning(
+                "GlobalMetaData has already been instantiated. "
+                "Returning the existing instance."
+            )
         return cls._instance
 
 

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -133,11 +133,23 @@ class CompactBinaryCoalescenceResult(CoreResult):
     def cosmology(self):
         """The global cosmology used in the analysis.
 
+        Will return None if the result does not include global meta data.
+        Inclusion of the the global meta is controlled by the
+        :code:`BILBY_INCLUDE_GLOBAL_META_DATA` environment variable.
+
         .. versionadded:: 2.5.0
         """
-        return self.__get_from_nested_meta_data(
-            'global_meta_data', 'cosmology'
-        )
+        try:
+            return self.__get_from_nested_meta_data(
+                'global_meta_data', 'cosmology'
+            )
+        except AttributeError as e:
+            logger.warning(
+                "No cosmology found in result. "
+                "This is likely due to the result not containing "
+                f"global meta data. Error: {e}."
+            )
+            return None
 
     def detector_injection_properties(self, detector):
         """ Returns a dictionary of the injection properties for each detector

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -18,7 +18,7 @@ Global meta data
 
 **Q:** I'm seeing a message about global meta data, what does this mean?
 
-**A:** In `bilby` 2.5.0, the global meta data dictionary was added to the result object
+**A:** In :code:`bilby` 2.5.0, the global meta data dictionary was added to the result object
 under :code:`result.meta_data["global_meta_data]`. This includes information such as the 
 global cosmology and random number generator. To ensure backwards compatibility,
 by default, this object is removed the result when it is instantiated.

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -21,10 +21,12 @@ Global meta data
 **A:** In :code:`bilby` 2.5.0, the global meta data dictionary was added to the result object
 under :code:`result.meta_data["global_meta_data]`. This includes information such as the 
 global cosmology and random number generator. To ensure backwards compatibility,
-by default, this object is removed the result when it is instantiated.
+by default, this dictionary is removed from the result object when it is instantiated.
 In a future release, this will be changed.
 In the meantime, you can include the global meta data by setting the
-global variable :code:`BILBY_INCLUDE_GLOBAL_META_DATA=1`. This can be either be done
-in the command line using :code:`export BILBY_INCLUDE_GLOBAL_META_DATA=1` or within
+global variable :code:`BILBY_INCLUDE_GLOBAL_META_DATA=1`
+(:code:`BILBY_INCLUDE_GLOBAL_META_DATA=0` excludes it).
+This can be either be done in the command line using
+:code:`export BILBY_INCLUDE_GLOBAL_META_DATA=1` or within
 python (e.g. using :code:`os`,
 :code:`os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = "1"`)

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -27,4 +27,4 @@ In the meantime, you can include the global meta data by setting the
 global variable :code:`BILBY_INCLUDE_GLOBAL_META_DATA=1`. This can be either be done
 in the command line using :code:`export BILBY_INCLUDE_GLOBAL_META_DATA=1` or within
 python (e.g. using :code:`os`,
-code:`os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = "1"`)
+:code:`os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = "1"`)

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -5,10 +5,26 @@ Frequently Asked Questions
 Plotting questions
 ------------------
 
-I'm running into latex errors when :code:`bilby` tries to create plots, what should I do?
+**Q:** I'm running into latex errors when :code:`bilby` tries to create plots, what should I do?
 
-Matplotlib can be a little finicky. We wrap plotting commands in a function
+**A:** Matplotlib can be a little finicky. We wrap plotting commands in a function
 which can set up the rcParams and we use environment variables to allow
 configuration of this. See the docstring of this :code:`bilby.core.utils.latex_plot_format`
 for the allowed configuration options.
 
+
+Global meta data
+----------------
+
+**Q:** I'm seeing a message about global meta data, what does this mean?
+
+**A:** In `bilby` 2.5.0, the global meta data dictionary was added to the result object
+under :code:`result.meta_data["global_meta_data]`. This includes information such as the 
+global cosmology and random number generator. To ensure backwards compatibility,
+by default, this object is removed the result when it is instantiated.
+In a future release, this will be changed.
+In the meantime, you can include the global meta data by setting the
+global variable :code:`BILBY_INCLUDE_GLOBAL_META_DATA=1`. This can be either be done
+in the command line using :code:`export BILBY_INCLUDE_GLOBAL_META_DATA=1` or within
+python (e.g. using :code:`os`,
+code:`os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = "1"`)

--- a/examples/gw_examples/injection_examples/fast_tutorial.py
+++ b/examples/gw_examples/injection_examples/fast_tutorial.py
@@ -19,7 +19,7 @@ minimum_frequency = 20
 # Specify the output directory and the name of the simulation.
 outdir = "outdir"
 label = "fast_tutorial"
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.setup_logger(outdir=outdir, label=label, log_level="DEBUG")
 
 # Set up a random seed for result reproducibility.  This is optional!
 bilby.core.utils.random.seed(88170235)

--- a/test/gw/result_test.py
+++ b/test/gw/result_test.py
@@ -222,7 +222,8 @@ class CBCResultsGlobalMetaDataTest(BaseCBCResultTest):
         self._caplog = caplog
 
     def setUp(self):
-        self.meta_data_env_var = os.getenv("BILBY_INCLUDE_GLOBAL_META_DATA")
+        # Current default is False
+        self.meta_data_env_var = os.getenv("BILBY_INCLUDE_GLOBAL_META_DATA") or "False"
         os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = self.include_global_meta_data
         super().setUp()
 


### PR DESCRIPTION
Rework `GlobalMetaData` to inherit from `dict` rather than `UserDict`.

This means any checks for `isinstance(o, dict)` will return `True` rather than `False`. This will hopefully address the issue seen in some downstream packages.

I've also added an environment variable called `BILBY_INCLUDE_GLOBAL_META_DATA` (open to suggestions for a better name) that toggles whether the meta data is included or not in the result object. By default, this is False, meaning it should be backwards compatible.

I also had to tweak the `cosmology` property in the CBC result now that it isn't always present.