### PR TITLE
TST: reduce random test failures

### DIFF
--- a/containers/env-template.yml
+++ b/containers/env-template.yml
@@ -22,6 +22,7 @@ dependencies:
   - black
   - pytest-cov
   - pytest-requires
+  - pytest-rerunfailures
   - conda-forge::arviz
   - parameterized
   - scikit-image

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -2,3 +2,4 @@ celerite
 george
 plotly
 pytest-requires
+pytest-rerunfailures

--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -832,7 +832,7 @@ class TestReweight(unittest.TestCase):
         self.result = bilby.core.result.Result(
             search_parameter_keys=list(self.priors.keys()),
             priors=self.priors,
-            posterior=pd.DataFrame(self.priors.sample(1000)),
+            posterior=pd.DataFrame(self.priors.sample(2000)),
             log_evidence=-np.log(10),
         )
 
@@ -857,6 +857,7 @@ class TestReweight(unittest.TestCase):
         _, weights, _, _, _, _ = self._run_reweighting(sigma=1)
         self.assertLess(min(abs(weights - 1)), 1e-10)
 
+    @pytest.mark.flaky(reruns=3)
     def test_reweight_different_likelihood_weights_correct(self):
         """
         Test the known case where the target likelihood is a Gaussian with


### PR DESCRIPTION
As noted in https://github.com/bilby-dev/bilby/pull/914#issuecomment-2656692523, a specific test in the CI seems to be randomly failing, `test_reweight_different_likelihood_weights_correct`.

I ran this test locally 100 times using `parameterized` and it seemed to fail ~3% of the time. 

To try and avoid this impacting the CI, I've made two changes:

- Increase the number of samples to 2000, when I ran this locally it significantly reduced the number of failures (I had to run it x100 multiple times)
- Add a `pytest` mark that will rerun the test if it fails. This requires a new dependency which I've added to `optional_requirements.txt` and the containers environment.