### PR TITLE
ENH: Add InterferometerList time domain plotting

### DIFF
--- a/bilby/gw/detector/networks.py
+++ b/bilby/gw/detector/networks.py
@@ -203,6 +203,43 @@ class InterferometerList(list):
         for interferometer in self:
             interferometer.plot_data(signal=signal, outdir=outdir, label=label)
 
+    def plot_time_domain_data(
+        self, outdir=".", label=None, bandpass_frequencies=(50, 250),
+        notches=None, start_end=None, t0=None
+    ):
+        """Plots the strain data in the time domain for each of the
+        interfeormeters
+
+        Parameters
+        ==========
+        outdir: str
+            The output directory in which the plots should be saved.
+        label: str
+            The string labelling the data.
+        bandpass_frequencies: tuple, optional
+            A tuple of the (low, high) frequencies to use when bandpassing
+            data, if None no bandpass is applied.
+        notches: list, optional
+            A list of frequencies specifying any lines to notch.
+        start_end: tuple, optional
+            A tuple of the (start, end) range of GPS times to plot.
+        t0: float, optional
+            If given, the reference time to subtract from the time series
+            plotting.
+        """
+        if utils.command_line_args.bilby_test_mode:
+            return
+
+        for interferometer in self:
+            interferometer.plot_time_domain_data(
+                outdir=outdir,
+                label=label,
+                bandpass_frequencies=bandpass_frequencies,
+                notches=notches,
+                start_end=start_end,
+                t0=t0
+            )
+
     @property
     def number_of_interferometers(self):
         return len(self)

--- a/test/gw/detector/networks_test.py
+++ b/test/gw/detector/networks_test.py
@@ -348,6 +348,15 @@ class TestInterferometerList(unittest.TestCase):
         ifos.set_strain_data_from_power_spectral_densities(2048, 4)
         ifos.plot_data(outdir=self.outdir)
 
+    def test_plot_time_domain_data(self):
+        ifos = bilby.gw.detector.InterferometerList(["H1", "L1"])
+        ifos.set_strain_data_from_power_spectral_densities(2048, 4)
+        ifos.plot_time_domain_data(outdir=self.outdir)
+
+        ifos = bilby.gw.detector.InterferometerList(["H1", "L1", "V1"])
+        ifos.set_strain_data_from_power_spectral_densities(2048, 4)
+        ifos.plot_time_domain_data(outdir=self.outdir)
+
 
 class TriangularInterferometerTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Currently, the InterferometerList class has the `plot_data` function for plotting the frequency domain strain for each of the detectors directly using their respective `plot_data` functions. However, to plot the time domain equivalent, one must loop the detectors manually. This PR simply adds an equivalent function for the `plot_time_domain_data` function. Testing has been added that mirrors the `plot_data` testing. 