### PR TITLE
DOC:Fixed README link for opening bilby_pipe issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ If you need help, find an issue, or just have a question/suggestion you can
 - Ask questions (or search through other users questions and answers) on `StackOverflow <https://stackoverflow.com/questions/tagged/bilby>`__ using the bilby tag
 - Submit issues directly through `the issue tracker <https://github.com/bilby-dev/bilby/issues>`__
 - For chat.ligo.org users, join the `#bilby-help <https://chat.ligo.org/ligo/channels/bilby-help>`__ or `#bilby-devel <https://chat.ligo.org/ligo/channels/bilby-devel>`__ channels
-- For LVK-confidential issues, please open `a confidential issue on bilby_pipe <https://github.com/bilby-dev/bilby_pipe/-/issues/new>`__
+- For LVK-confidential issues, please open `a confidential issue on bilby_pipe <https://git.ligo.org/lscsoft/bilby_pipe/-/issues/new>`__
 
 We encourage you to contribute to the development of bilby. This is done via pull request.  For
 help in creating a pull request, see `this page


### PR DESCRIPTION
The link for opening bilby_pipe issues currently is broken as it points within the bilby-dec github, this MR restores it to point to the LVK gitlab. 