### PR TITLE
BUG: ensure directory exists when reweighting

### DIFF
--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -194,7 +194,9 @@ def get_weights_for_reweighting(
 
         starting_index = np.argmin(np.abs(old_log_likelihood_array))
         logger.info(f'Checkpoint resuming from {starting_index}.')
-
+    elif resume_file is not None:
+        basedir = os.split(resume_file)[0]
+        check_directory_exists_and_if_not_mkdir(basedir)
     else:
         old_log_likelihood_array = np.zeros(nposterior)
         old_log_prior_array = np.zeros(nposterior)

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -195,7 +195,7 @@ def get_weights_for_reweighting(
         starting_index = np.argmin(np.abs(old_log_likelihood_array))
         logger.info(f'Checkpoint resuming from {starting_index}.')
     elif resume_file is not None:
-        basedir = os.split(resume_file)[0]
+        basedir = os.path.split(resume_file)[0]
         check_directory_exists_and_if_not_mkdir(basedir)
     else:
         old_log_likelihood_array = np.zeros(nposterior)


### PR DESCRIPTION
Ensure the output directory exists when checkpointing the reweighting process.

**Context**

When using reweighting results using `bilby_pipe` if `outdir/result` does not exist, the process fails with the following error:

```
FileNotFoundError: [Errno 2] No such file or directory: 'high_spin_reweighting_marg_outdir/result/bilby-IMRPhenomPv2-NRTidalv2-RB-highspin-3_reweighted_reweight_resume.pkl
``` 

As fas as I can tell, this is because `high_spin_reweighting_marg_outdir/result` is not made automatically.

**Changes**

In `get_weights_for_reweighting` ensure the directory for the resume file exists.