### PR TITLE
BUG: Use "geocent" not "geocenter" where appropriate

### DIFF
--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -1683,7 +1683,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
 
         if (
             not getattr(likelihood, "reference_frame", "sky") == "sky"
-            or not getattr(likelihood, "time_reference", "geocenter") == "geocenter"
+            or not getattr(likelihood, "time_reference", "geocent") == "geocent"
         ):
             try:
                 generate_sky_frame_parameters(

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -1683,7 +1683,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
 
         if (
             not getattr(likelihood, "reference_frame", "sky") == "sky"
-            or not getattr(likelihood, "time_reference", "geocent") == "geocent"
+            or "geocent" not in getattr(likelihood, "time_reference", "geocent")
         ):
             try:
                 generate_sky_frame_parameters(


### PR DESCRIPTION
In the conditional of `generate_posterior_samples_from_marginalized_likelihood`, checks for the value of `likelihood.time_reference` which will actually occur. Fixes https://github.com/bilby-dev/bilby/issues/929.