### PR TITLE
BUG: fix injection parameters being fixed during recovery

### DIFF
--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 import inspect
 import sys
-from copy import deepcopy
 
 from ..prior import DeltaFunction, PriorDict
 from ..utils import (
@@ -339,15 +338,10 @@ def run_sampler(
             result.save_to_file(extension=save, gzip=gzip, outdir=outdir)
 
     if None not in [result.injection_parameters, conversion_function]:
-        # the conversion function can modify the likelihood parameters in place
-        # this can break things for the conversion over the posterior samples
-        old_parameters = deepcopy(likelihood.parameters)
         result.injection_parameters = conversion_function(
             result.injection_parameters,
             likelihood=likelihood,
         )
-        likelihood.parameters.clear()
-        likelihood.parameters.update(old_parameters)
 
     # Check if the posterior has already been created
     if getattr(result, "_posterior", None) is None:

--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 import inspect
 import sys
+from copy import deepcopy
 
 from ..prior import DeltaFunction, PriorDict
 from ..utils import (
@@ -338,10 +339,15 @@ def run_sampler(
             result.save_to_file(extension=save, gzip=gzip, outdir=outdir)
 
     if None not in [result.injection_parameters, conversion_function]:
+        # the conversion function can modify the likelihood parameters in place
+        # this can break things for the conversion over the posterior samples
+        old_parameters = deepcopy(likelihood.parameters)
         result.injection_parameters = conversion_function(
             result.injection_parameters,
             likelihood=likelihood,
         )
+        likelihood.parameters.clear()
+        likelihood.parameters.update(old_parameters)
 
     # Check if the posterior has already been created
     if getattr(result, "_posterior", None) is None:

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -1704,7 +1704,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
             logger.info(
                 "Generation of {} parameters failed with message {}".format(
                     key, e))
-    
+
     if likelihood is not None:
         likelihood.parameters.clear()
         likelihood.parameters.update(initial_likelihood_parameters)

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -1730,7 +1730,7 @@ def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1):
 
     .. versionchanged:: 2.5.1
        To ensure that internal state of :code:`likelihood` is not changed by
-       this function. The initial value of :code:`likelihood.parameters` are
+       this function, the initial value of :code:`likelihood.parameters` are
        saved and reset at the end of the function.
     """
     waveform_defaults = {
@@ -1766,7 +1766,7 @@ def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1):
 
     .. versionchanged:: 2.5.1
        To ensure that internal state of :code:`likelihood` is not changed by
-       this function. The initial value of :code:`likelihood.parameters` are
+       this function, the initial value of :code:`likelihood.parameters` are
        saved and reset at the end of the function.
     """
     waveform_defaults = {

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -7,6 +7,7 @@ import os
 import sys
 import multiprocessing
 import pickle
+from copy import deepcopy
 
 import numpy as np
 from pandas import DataFrame, Series
@@ -1633,6 +1634,12 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
                                  likelihood=None, priors=None, npool=1):
     """Generate all cbc parameters, helper function for BBH/BNS"""
     output_sample = sample.copy()
+
+    if likelihood is not None:
+        # make a copy of the state of the likelihood so that changes during
+        # e.g., marginalized posterior reconstruction don't get retained
+        initial_likelihood_parameters = deepcopy(likelihood.parameters)
+
     waveform_defaults = defaults
     for key in waveform_defaults:
         try:
@@ -1697,6 +1704,11 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
             logger.info(
                 "Generation of {} parameters failed with message {}".format(
                     key, e))
+    
+    if likelihood is not None:
+        likelihood.parameters.clear()
+        likelihood.parameters.update(initial_likelihood_parameters)
+
     return output_sample
 
 
@@ -1715,6 +1727,11 @@ def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1):
         likelihood.interferometers.
     priors: dict, optional
         Dictionary of prior objects, used to fill in non-sampled parameters.
+
+    .. versionchanged:: 2.5.1
+       To ensure that internal state of :code:`likelihood` is not changed by
+       this function. The initial value of :code:`likelihood.parameters` are
+       saved and reset at the end of the function.
     """
     waveform_defaults = {
         'reference_frequency': 50.0, 'waveform_approximant': 'IMRPhenomPv2',
@@ -1747,6 +1764,10 @@ def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1):
     npool: int, (default=1)
         If given, perform generation (where possible) using a multiprocessing pool
 
+    .. versionchanged:: 2.5.1
+       To ensure that internal state of :code:`likelihood` is not changed by
+       this function. The initial value of :code:`likelihood.parameters` are
+       saved and reset at the end of the function.
     """
     waveform_defaults = {
         'reference_frequency': 50.0, 'waveform_approximant': 'TaylorF2',

--- a/test/gw/conversion_test.py
+++ b/test/gw/conversion_test.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -513,6 +514,8 @@ class TestGenerateAllParameters(unittest.TestCase):
         self.parameters["time_jitter"] = 0.0
         del self.parameters["ra"], self.parameters["dec"]
         self.parameters = pd.DataFrame(self.parameters, index=range(1))
+        likelihood.parameters["mass_1"] = -1.0
+        initial_likelihood_parameters = deepcopy(likelihood.parameters)
         converted = bilby.gw.conversion.generate_all_bbh_parameters(
             sample=self.parameters, likelihood=likelihood, priors=priors
         )
@@ -528,6 +531,9 @@ class TestGenerateAllParameters(unittest.TestCase):
         ]
         for key in extra_expected:
             self.assertIn(key, converted)
+        # make sure conversion didn't clobber likelihood state
+        self.assertEqual(initial_likelihood_parameters, likelihood.parameters)
+        self.assertNotEqual(converted["mass_1"].values[0], likelihood.parameters["mass_1"])
 
     def test_identity_generation_no_likelihood(self):
         test_fixed_prior = bilby.core.prior.PriorDict({


### PR DESCRIPTION
#900 introduced a bug in the recovery of distance posteriors when using distance marginalization (among other things). This resolves the issue, but I'm not convinced that this is the best solution.

In general, I think this kind of situation is fairly unavoidable as we store the parameter values in the likelihood.