### PR TITLE
ENH: Dynesty: Allow printing dlogz below 1e-3

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -392,7 +392,7 @@ class Dynesty(NestedSampler):
         if logl_min > -np.inf:
             string.append(f"logl:{logl_min:.1f} < {loglstar:.1f} < {logl_max:.1f}")
         if dlogz is not None:
-            string.append(f"dlogz:{delta_logz:0.3f}>{dlogz:0.2g}")
+            string.append(f"dlogz:{delta_logz:0.3g}>{dlogz:0.2g}")
         else:
             string.append(f"stop:{stop_val:6.3f}")
         string = " ".join(string)


### PR DESCRIPTION
Sometimes, one wants to explore lower thresholds for the stopping criterion. Without this change the values for dlogz below 1e-3 will be shown as 0.000. With this change, these numbers will be printed in scientific notation after they become sufficiently small.