### PR TITLE
BUG: Fix sampling efficiency warning

### DIFF
--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -441,6 +441,23 @@ class PriorDict(dict):
         return [k for k, p in self.items() if isinstance(p, Constraint)]
 
     def sample_subset_constrained(self, keys=iter([]), size=None):
+        """
+        Sample a subset of priors while ensuring constraints are satisfied.
+
+        Parameters
+        ==========
+        keys: list
+            List of prior keys to sample from.
+        size: int
+            The number of samples to draw.
+
+        Returns
+        =======
+        dict: Dictionary of valid samples.
+        """
+        if not any(isinstance(self[key], Constraint) for key in self):
+            return self.sample_subset(keys=keys, size=size)
+
         efficiency_warning_was_issued = False
 
         def check_efficiency(n_tested, n_valid):


### PR DESCRIPTION
This pull request fixes the bug reported in #938 and #944.

The issue is that, even for 100% efficient priors, like

```python
priors = bilby.core.prior.PriorDict()
priors["mass_1"] = bilby.core.prior.Uniform(minimum=1.2, maximum=2)
```

the following warning shows up when drawing a sufficiently large number of samples [here `priors.sample(1_000_000)`]:

```
21:25 bilby WARNING : Prior sampling efficiency is very low, please verify its validity.
```

The warning materialises because the `sample_subset_constrained` method of `PriorDict` assumes that the priors include at least one `Constraint` prior.

I have also added a very simple unit test to check for this warning.