### PR TITLE
DOC: Correct docs for use_ratio argument of run_sampler

### DIFF
--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -179,9 +179,13 @@ def run_sampler(
         `bilby.sampler.get_implemented_samplers()` for a list of available
         samplers.
         Alternatively a Sampler object can be passed
-    use_ratio: bool (False)
-        If True, use the likelihood's log_likelihood_ratio, rather than just
-        the log_likelihood.
+    use_ratio: bool (None)
+        If True, use the likelihood's `log_likelihood_ratio`, rather than just
+        the `log_likelihood`. If left as the default value of `None`, and the
+        likelihood has a valid `log_likelihood_ratio` method, then that method
+        will also be used, i.e., the likelihood ratio will be calculated. To
+        ensure that the `log_likelihood` method is used for the calculation,
+        rather than the likelihood ratio, this argument should be set to False.
     injection_parameters: dict
         A dictionary of injection parameters used in creating the data (if
         using simulated data). Appended to the result object and saved.


### PR DESCRIPTION
As described in #927, if using the `run_sampler` function, the default value of `use_ratio` is `None`, which actually results in the likelihood ratio being calculated if the likelihood contains a valid `log_likelihood_ratio` method. This is at odds with the doc string which states that the default value of `use_ratio` is `False`. This PR fixes the doc string to be consistent with the actual way the code works.