### PR TITLE
BUG: remove incorrect window-based PSD scaling

### DIFF
--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -492,6 +492,17 @@ class Interferometer(object):
             logger.info('  {} = {}'.format(key, parameters[key]))
 
     @property
+    def _window_power_correction(self):
+        """
+        This property enables the old (incorrect) PSD correction to be applied
+        using the :code:`BILBY_INCORRECT_PSD_NORMALIZATION` environment variable.
+        """
+        if os.environ.get("BILBY_INCORRECT_PSD_NORMALIZATION", "FALSE").upper() == "TRUE":
+            return self.strain_data.window_factor
+        else:
+            return 1
+
+    @property
     def amplitude_spectral_density_array(self):
         """ Returns the amplitude spectral density (ASD) given we know a power spectral density (PSD)
 
@@ -502,7 +513,7 @@ class Interferometer(object):
         """
         return self.power_spectral_density.get_amplitude_spectral_density_array(
             frequency_array=self.strain_data.frequency_array
-        )
+        ) * self._window_power_correction**0.5
 
     @property
     def power_spectral_density_array(self):
@@ -517,7 +528,7 @@ class Interferometer(object):
         """
         return self.power_spectral_density.get_power_spectral_density_array(
             frequency_array=self.strain_data.frequency_array
-        )
+        ) * self._window_power_correction
 
     def unit_vector_along_arm(self, arm):
         logger.warning("This method has been moved and will be removed in the future."

--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -516,7 +516,7 @@ class Interferometer(object):
 
         """
         return self.power_spectral_density.get_power_spectral_density_array(
-                frequency_array=self.strain_data.frequency_array
+            frequency_array=self.strain_data.frequency_array
         )
 
     def unit_vector_along_arm(self, arm):

--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -500,10 +500,9 @@ class Interferometer(object):
         array_like: An array representation of the ASD
 
         """
-        return (
-            self.power_spectral_density.get_amplitude_spectral_density_array(
-                frequency_array=self.strain_data.frequency_array) *
-            self.strain_data.window_factor**0.5)
+        return self.power_spectral_density.get_amplitude_spectral_density_array(
+            frequency_array=self.strain_data.frequency_array
+        )
 
     @property
     def power_spectral_density_array(self):
@@ -516,10 +515,9 @@ class Interferometer(object):
         array_like: An array representation of the PSD
 
         """
-        return (
-            self.power_spectral_density.get_power_spectral_density_array(
-                frequency_array=self.strain_data.frequency_array) *
-            self.strain_data.window_factor)
+        return self.power_spectral_density.get_power_spectral_density_array(
+                frequency_array=self.strain_data.frequency_array
+        )
 
     def unit_vector_along_arm(self, arm):
         logger.warning("This method has been moved and will be removed in the future."

--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -9,6 +9,7 @@ from bilby_cython.geometry import (
 
 from ...core import utils
 from ...core.utils import docstring, logger, PropertyAccessor, safe_file_dump
+from ...core.utils.env import string_to_boolean
 from .. import utils as gwutils
 from .calibration import Recalibrate
 from .geometry import InterferometerGeometry
@@ -497,7 +498,9 @@ class Interferometer(object):
         This property enables the old (incorrect) PSD correction to be applied
         using the :code:`BILBY_INCORRECT_PSD_NORMALIZATION` environment variable.
         """
-        if os.environ.get("BILBY_INCORRECT_PSD_NORMALIZATION", "FALSE").upper() == "TRUE":
+        if string_to_boolean(
+            os.environ.get("BILBY_INCORRECT_PSD_NORMALIZATION", "FALSE").upper()
+        ):
             return self.strain_data.window_factor
         else:
             return 1

--- a/test/gw/detector/interferometer_test.py
+++ b/test/gw/detector/interferometer_test.py
@@ -383,18 +383,16 @@ def test_psd_not_impacted_by_window_factor(monkeypatch):
         ifo.power_spectral_density_array
     )
 
+
 def test_psd_impacted_by_window_factor_with_environment_variable(monkeypatch):
-    env = dict(BILBY_INCORRECT_PSD_NORMALIZATION="TRUE")
-    monkeypatch.setattr(os, "environ", env)
     ifo = bilby.gw.detector.get_empty_interferometer("H1")
     ifo.set_strain_data_from_zero_noise(duration=4, sampling_frequency=256)
-    monkeypatch.setattr(ifo.strain_data, "window_factor", 0.1)
-    np.testing.assert_array_equal(
-        ifo.power_spectral_density.get_power_spectral_density_array(
-            frequency_array=ifo.strain_data.frequency_array
-        ) * 0.1,
-        ifo.power_spectral_density_array
-    )
+    old_psd = ifo.power_spectral_density_array
+    factor = 0.1
+    env = dict(BILBY_INCORRECT_PSD_NORMALIZATION="TRUE")
+    monkeypatch.setattr(os, "environ", env)
+    monkeypatch.setattr(ifo.strain_data, "window_factor", factor)
+    np.testing.assert_array_equal(old_psd * factor, ifo.power_spectral_density_array)
 
 
 class TestInterferometerEquals(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a longstanding bug in the likelihood when using windowed time-domain data. The addition of the window factor was due to a misunderstanding of what quantity should be whitened. The change made here will ensure that the data containing the signal is correctly whitened.

Closes #869 