### PR TITLE
MAINT: np.trapz -> np.trapezoid

### DIFF
--- a/bilby/bilby_mcmc/sampler.py
+++ b/bilby/bilby_mcmc/sampler.py
@@ -1090,8 +1090,8 @@ class BilbyPTMCMCSampler(object):
 
     @staticmethod
     def _compute_evidence_from_mean_lnlikes(betas, mean_lnlikes):
-        lnZ = np.trapz(mean_lnlikes, betas)
-        z2 = np.trapz(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
+        lnZ = np.trapezoid(mean_lnlikes, betas)
+        z2 = np.trapezoid(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
         lnZerr = np.abs(lnZ - z2)
         return lnZ, lnZerr
 

--- a/bilby/bilby_mcmc/sampler.py
+++ b/bilby/bilby_mcmc/sampler.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from scipy.integrate import trapezoid
 from scipy.optimize import differential_evolution
 
 from ..core.result import rejection_sample
@@ -1090,8 +1091,8 @@ class BilbyPTMCMCSampler(object):
 
     @staticmethod
     def _compute_evidence_from_mean_lnlikes(betas, mean_lnlikes):
-        lnZ = np.trapezoid(mean_lnlikes, betas)
-        z2 = np.trapezoid(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
+        lnZ = trapezoid(mean_lnlikes, betas)
+        z2 = trapezoid(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
         lnZerr = np.abs(lnZ - z2)
         return lnZ, lnZerr
 

--- a/bilby/core/prior/interpolated.py
+++ b/bilby/core/prior/interpolated.py
@@ -163,9 +163,9 @@ class Interped(Prior):
 
     def _initialize_attributes(self):
         from scipy.integrate import cumulative_trapezoid
-        if np.trapz(self._yy, self.xx) != 1:
+        if np.trapezoid(self._yy, self.xx) != 1:
             logger.debug('Supplied PDF for {} is not normalised, normalising.'.format(self.name))
-        self._yy /= np.trapz(self._yy, self.xx)
+        self._yy /= np.trapezoid(self._yy, self.xx)
         self.YY = cumulative_trapezoid(self._yy, self.xx, initial=0)
         # Need last element of cumulative distribution to be exactly one.
         self.YY[-1] = 1

--- a/bilby/core/prior/interpolated.py
+++ b/bilby/core/prior/interpolated.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.integrate import trapezoid
 from scipy.interpolate import interp1d
 
 from .base import Prior
@@ -163,9 +164,9 @@ class Interped(Prior):
 
     def _initialize_attributes(self):
         from scipy.integrate import cumulative_trapezoid
-        if np.trapezoid(self._yy, self.xx) != 1:
+        if trapezoid(self._yy, self.xx) != 1:
             logger.debug('Supplied PDF for {} is not normalised, normalising.'.format(self.name))
-        self._yy /= np.trapezoid(self._yy, self.xx)
+        self._yy /= trapezoid(self._yy, self.xx)
         self.YY = cumulative_trapezoid(self._yy, self.xx, initial=0)
         # Need last element of cumulative distribution to be exactly one.
         self.YY[-1] = 1

--- a/bilby/core/sampler/ptemcee.py
+++ b/bilby/core/sampler/ptemcee.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 import numpy as np
 import pandas as pd
+from scipy.integrate import trapezoid
 
 from ..utils import check_directory_exists_and_if_not_mkdir, logger, safe_file_dump
 from .base_sampler import (
@@ -1396,9 +1397,9 @@ def compute_evidence(
         mean_lnlikes = mean_lnlikes[~idxs]
         betas = betas[~idxs]
 
-    lnZ = np.trapezoid(mean_lnlikes, betas)
-    z1 = np.trapezoid(mean_lnlikes, betas)
-    z2 = np.trapezoid(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
+    lnZ = trapezoid(mean_lnlikes, betas)
+    z1 = trapezoid(mean_lnlikes, betas)
+    z2 = trapezoid(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
     lnZerr = np.abs(z1 - z2)
 
     if make_plots:
@@ -1410,7 +1411,7 @@ def compute_evidence(
         evidence = []
         for i in range(int(len(betas) / 2.0)):
             min_betas.append(betas[i])
-            evidence.append(np.trapezoid(mean_lnlikes[i:], betas[i:]))
+            evidence.append(trapezoid(mean_lnlikes[i:], betas[i:]))
 
         ax2.semilogx(min_betas, evidence, "-o")
         ax2.set_ylabel(

--- a/bilby/core/sampler/ptemcee.py
+++ b/bilby/core/sampler/ptemcee.py
@@ -1396,9 +1396,9 @@ def compute_evidence(
         mean_lnlikes = mean_lnlikes[~idxs]
         betas = betas[~idxs]
 
-    lnZ = np.trapz(mean_lnlikes, betas)
-    z1 = np.trapz(mean_lnlikes, betas)
-    z2 = np.trapz(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
+    lnZ = np.trapezoid(mean_lnlikes, betas)
+    z1 = np.trapezoid(mean_lnlikes, betas)
+    z2 = np.trapezoid(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
     lnZerr = np.abs(z1 - z2)
 
     if make_plots:
@@ -1410,7 +1410,7 @@ def compute_evidence(
         evidence = []
         for i in range(int(len(betas) / 2.0)):
             min_betas.append(betas[i])
-            evidence.append(np.trapz(mean_lnlikes[i:], betas[i:]))
+            evidence.append(np.trapezoid(mean_lnlikes[i:], betas[i:]))
 
         ax2.semilogx(min_betas, evidence, "-o")
         ax2.set_ylabel(

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -1520,7 +1520,7 @@ class HealPixMapPriorDist(BaseJointPriorDist):
         """
         from scipy.integrate import cumulative_trapezoid
         yy = self._all_interped(self.pix_xx)
-        yy /= np.trapz(yy, self.pix_xx)
+        yy /= np.trapezoid(yy, self.pix_xx)
         YY = cumulative_trapezoid(yy, self.pix_xx, initial=0)
         YY[-1] = 1
         self.inverse_cdf = interp1d(x=YY, y=self.pix_xx, bounds_error=True)

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -2,7 +2,7 @@ import os
 import copy
 
 import numpy as np
-from scipy.integrate import quad
+from scipy.integrate import quad, trapezoid
 from scipy.interpolate import InterpolatedUnivariateSpline, interp1d
 from scipy.special import hyp2f1
 from scipy.stats import norm
@@ -1520,7 +1520,7 @@ class HealPixMapPriorDist(BaseJointPriorDist):
         """
         from scipy.integrate import cumulative_trapezoid
         yy = self._all_interped(self.pix_xx)
-        yy /= np.trapezoid(yy, self.pix_xx)
+        yy /= trapezoid(yy, self.pix_xx)
         YY = cumulative_trapezoid(yy, self.pix_xx, initial=0)
         YY[-1] = 1
         self.inverse_cdf = interp1d(x=YY, y=self.pix_xx, bounds_error=True)

--- a/examples/core_examples/multivariate_gaussian_prior.py
+++ b/examples/core_examples/multivariate_gaussian_prior.py
@@ -75,7 +75,7 @@ for j in range(2):  # loop over parameters
     gp = np.zeros(len(x))
     for i in range(nmodes):  # loop over modes
         gp += weights[i] * stats.norm.pdf(x, loc=mus[i][j], scale=mvg.sigmas[i][j])
-    gp = gp / np.trapz(gp, x)  # renormalise
+    gp = gp / np.trapezoid(gp, x)  # renormalise
 
     axs[aidx[j]].plot(x, gp, "k--", lw=2)
 

--- a/examples/core_examples/multivariate_gaussian_prior.py
+++ b/examples/core_examples/multivariate_gaussian_prior.py
@@ -9,6 +9,7 @@ import matplotlib as mpl
 import numpy as np
 from bilby.core.likelihood import GaussianLikelihood
 from scipy import linalg, stats
+from scipy.integrate import trapezoid
 
 # A few simple setup steps
 label = "multivariate_gaussian_prior"
@@ -75,7 +76,7 @@ for j in range(2):  # loop over parameters
     gp = np.zeros(len(x))
     for i in range(nmodes):  # loop over modes
         gp += weights[i] * stats.norm.pdf(x, loc=mus[i][j], scale=mvg.sigmas[i][j])
-    gp = gp / np.trapezoid(gp, x)  # renormalise
+    gp = gp / trapezoid(gp, x)  # renormalise
 
     axs[aidx[j]].plot(x, gp, "k--", lw=2)
 

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -573,7 +573,7 @@ class TestPriorClasses(unittest.TestCase):
                 domain = np.linspace(prior.minimum, prior.maximum, 10000)
             else:
                 domain = np.linspace(prior.minimum, prior.maximum, 1000)
-            self.assertAlmostEqual(np.trapz(prior.prob(domain), domain), 1, 3)
+            self.assertAlmostEqual(np.trapezoid(prior.prob(domain), domain), 1, 3)
 
     def test_accuracy(self):
         """Test that each of the priors' functions is calculated accurately, as compared to scipy's calculations"""

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import os
 import scipy.stats as ss
+from scipy.integrate import trapezoid
 
 
 class TestPriorClasses(unittest.TestCase):
@@ -573,7 +574,7 @@ class TestPriorClasses(unittest.TestCase):
                 domain = np.linspace(prior.minimum, prior.maximum, 10000)
             else:
                 domain = np.linspace(prior.minimum, prior.maximum, 1000)
-            self.assertAlmostEqual(np.trapezoid(prior.prob(domain), domain), 1, 3)
+            self.assertAlmostEqual(trapezoid(prior.prob(domain), domain), 1, 3)
 
     def test_accuracy(self):
         """Test that each of the priors' functions is calculated accurately, as compared to scipy's calculations"""

--- a/test/gw/likelihood/marginalization_test.py
+++ b/test/gw/likelihood/marginalization_test.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 import numpy as np
 import bilby
 from bilby.gw.detector import calibration
+from scipy.integrate import trapezoid
 from scipy.special import logsumexp
 
 
@@ -380,7 +381,7 @@ class TestMarginalizations(unittest.TestCase):
             ln_likes[ii] = non_marginalized.log_likelihood_ratio()
         like = np.exp(ln_likes - max(ln_likes))
 
-        marg_like = np.log(np.trapezoid(like * prior_values, values)) + max(ln_likes)
+        marg_like = np.log(trapezoid(like * prior_values, values)) + max(ln_likes)
         self.assertAlmostEqual(
             marg_like, marginalized.log_likelihood_ratio(), delta=0.5
         )

--- a/test/gw/likelihood/marginalization_test.py
+++ b/test/gw/likelihood/marginalization_test.py
@@ -380,7 +380,7 @@ class TestMarginalizations(unittest.TestCase):
             ln_likes[ii] = non_marginalized.log_likelihood_ratio()
         like = np.exp(ln_likes - max(ln_likes))
 
-        marg_like = np.log(np.trapz(like * prior_values, values)) + max(ln_likes)
+        marg_like = np.log(np.trapezoid(like * prior_values, values)) + max(ln_likes)
         self.assertAlmostEqual(
             marg_like, marginalized.log_likelihood_ratio(), delta=0.5
         )


### PR DESCRIPTION
`trapz` was removed from numpy in a recent release in favour of `trapezoid`. This PR changes the instances of `np.trapz` throughout the codebase.