### PR TITLE
TST: Restrict numpy version for dynesty compatibility

### DIFF
--- a/containers/env-template.yml
+++ b/containers/env-template.yml
@@ -9,7 +9,7 @@ dependencies:
   - setuptools
   - setuptools_scm
   - matplotlib
-  - numpy
+  - numpy<2.2  # dynesty<2.2 requires numpy<2.2
   - scipy
   - pandas
   - astropy


### PR DESCRIPTION
After we fix the numpy incompatibilities in #979 and #980 the remaining numpy issue will be in dynesty, since that will need #950 we should be able to remove this pin when a new release of dynesty is available.