### PR TITLE
CI: add merge_group to enable merge queue

### DIFF
--- a/.github/workflows/basic-install.yml
+++ b/.github/workflows/basic-install.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   release:
     types:
       - published

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   release:
     types:
       - published

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   release:
     types:
       - published

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   release:
     types:
       - published


### PR DESCRIPTION
Add `merge_group` to the CI workflows that usually run for PRs. This will enable us to use [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue)

Closes #895 