### PR TITLE
FEAT: Improve interactions of user pools

### DIFF
--- a/bilby/bilby_mcmc/sampler.py
+++ b/bilby/bilby_mcmc/sampler.py
@@ -15,7 +15,6 @@ from ..core.sampler.base_sampler import (
     MCMCSampler,
     ResumeError,
     SamplerError,
-    _sampling_convenience_dump,
     signal_wrapper,
 )
 from ..core.utils import (
@@ -24,6 +23,7 @@ from ..core.utils import (
     random,
     safe_file_dump,
 )
+from ..core.utils.parallel import sampling_convenience_dump
 from . import proposals
 from .chain import Chain, Sample
 from .utils import LOGLKEY, LOGPKEY, ConvergenceInputs, ParallelTemperingInputs
@@ -284,7 +284,7 @@ class Bilby_MCMC(MCMCSampler):
             total_steps=ptsampler.position,
             nsamples=ptsampler.nsamples,
         )
-        if ptsampler.pool is not None:
+        if ptsampler.pool is not None and hasattr(ptsampler.pool, "_processes"):
             npool = ptsampler.pool._processes
         else:
             npool = 1
@@ -615,7 +615,7 @@ class BilbyPTMCMCSampler(object):
 
         self._nsamples_dict = {}
         self.ensemble_proposal_cycle = proposals.get_default_ensemble_proposal_cycle(
-            _sampling_convenience_dump.priors
+            sampling_convenience_dump.priors
         )
         self.sampling_time = 0
         self.ln_z_dict = dict()
@@ -630,7 +630,7 @@ class BilbyPTMCMCSampler(object):
         elif pt_inputs.Tmax is not None:
             betas = np.logspace(0, -np.log10(pt_inputs.Tmax), pt_inputs.ntemps)
         elif pt_inputs.Tmax_from_SNR is not None:
-            ndim = len(_sampling_convenience_dump.priors.non_fixed_keys)
+            ndim = len(sampling_convenience_dump.priors.non_fixed_keys)
             target_hot_likelihood = ndim / 2
             Tmax = pt_inputs.Tmax_from_SNR**2 / (2 * target_hot_likelihood)
             betas = np.logspace(0, -np.log10(Tmax), pt_inputs.ntemps)
@@ -1172,15 +1172,15 @@ class BilbyMCMCSampler(object):
         self.Eindex = Eindex
         self.use_ratio = use_ratio
         self.normalize_prior = normalize_prior
-        self.parameters = _sampling_convenience_dump.priors.non_fixed_keys
+        self.parameters = sampling_convenience_dump.priors.non_fixed_keys
         self.ndim = len(self.parameters)
 
         if initial_sample_method.lower() == "prior":
-            full_sample_dict = _sampling_convenience_dump.priors.sample()
+            full_sample_dict = sampling_convenience_dump.priors.sample()
             initial_sample = {
                 k: v
                 for k, v in full_sample_dict.items()
-                if k in _sampling_convenience_dump.priors.non_fixed_keys
+                if k in sampling_convenience_dump.priors.non_fixed_keys
             }
         elif initial_sample_method.lower() in ["maximize", "maximise", "maximum"]:
             initial_sample = get_initial_maximimum_posterior_sample(self.beta)
@@ -1217,7 +1217,7 @@ class BilbyMCMCSampler(object):
 
             self.proposal_cycle = proposals.get_proposal_cycle(
                 proposal_cycle,
-                _sampling_convenience_dump.priors,
+                sampling_convenience_dump.priors,
                 L1steps=self.chain.L1steps,
                 warn=warn,
             )
@@ -1236,16 +1236,16 @@ class BilbyMCMCSampler(object):
         self.stop_after_convergence = convergence_inputs.stop_after_convergence
 
     def log_likelihood(self, sample):
-        params = deepcopy(_sampling_convenience_dump.parameters)
+        params = deepcopy(sampling_convenience_dump.parameters)
         params.update(sample.sample_dict)
 
         if self.use_ratio:
-            return _sampling_convenience_dump.likelihood.log_likelihood_ratio(params)
+            return sampling_convenience_dump.likelihood.log_likelihood_ratio(params)
         else:
-            return _sampling_convenience_dump.likelihood.log_likelihood(params)
+            return sampling_convenience_dump.likelihood.log_likelihood(params)
 
     def log_prior(self, sample):
-        return _sampling_convenience_dump.priors.ln_prob(
+        return sampling_convenience_dump.priors.ln_prob(
             sample.parameter_only_dict,
             normalized=self.normalize_prior,
         )
@@ -1273,8 +1273,8 @@ class BilbyMCMCSampler(object):
             proposal = self.proposal_cycle.get_proposal()
             prop, log_factor = proposal(
                 self.chain,
-                likelihood=_sampling_convenience_dump.likelihood,
-                priors=_sampling_convenience_dump.priors,
+                likelihood=sampling_convenience_dump.likelihood,
+                priors=sampling_convenience_dump.priors,
             )
             logp = self.log_prior(prop)
 
@@ -1350,10 +1350,8 @@ class BilbyMCMCSampler(object):
         zerotemp_logl = hot_samples[LOGLKEY]
 
         # Revert to true likelihood if needed
-        if _sampling_convenience_dump.use_ratio:
-            zerotemp_logl += (
-                _sampling_convenience_dump.likelihood.noise_log_likelihood()
-            )
+        if sampling_convenience_dump.use_ratio:
+            zerotemp_logl += sampling_convenience_dump.likelihood.noise_log_likelihood()
 
         # Calculate normalised weights
         log_weights = (1 - beta) * zerotemp_logl
@@ -1383,9 +1381,9 @@ def get_initial_maximimum_posterior_sample(beta):
 
     """
     logger.info("Finding initial maximum posterior estimate")
-    likelihood = _sampling_convenience_dump.likelihood
-    priors = _sampling_convenience_dump.priors
-    search_parameter_keys = _sampling_convenience_dump.search_parameter_keys
+    likelihood = sampling_convenience_dump.likelihood
+    priors = sampling_convenience_dump.priors
+    search_parameter_keys = sampling_convenience_dump.search_parameter_keys
 
     bounds = []
     for key in search_parameter_keys:
@@ -1398,7 +1396,7 @@ def get_initial_maximimum_posterior_sample(beta):
         if np.isinf(ln_prior):
             return -np.inf
 
-        parameters = deepcopy(_sampling_convenience_dump.parameters)
+        parameters = deepcopy(sampling_convenience_dump.parameters)
         parameters.update(sample)
 
         return -beta * likelihood.log_likelihood(parameters) - ln_prior

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -247,11 +247,11 @@ def get_weights_for_reweighting(
     def eval_pool(this_logl):
         from .utils.parallel import bilby_pool
 
-        chunksize = max(100, n // (2 * npool))
         with bilby_pool(likelihood=this_logl, npool=npool) as my_pool:
             if my_pool is None:
                 map_fn = map
             else:
+                chunksize = max(100, n // (2 * npool))
                 map_fn = partial(my_pool.imap, chunksize=chunksize)
             likelihood_fn = partial(_safe_likelihood_call, this_logl)
 

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -252,10 +252,11 @@ def get_weights_for_reweighting(
         if my_pool is None:
             map_fn = map
         else:
-            map_fn = my_pool.imap
+            map_fn = partial(my_pool.imap, chunksize=chunksize)
+        likelihood_fn = partial(_safe_likelihood_call, this_logl)
 
         log_l = list(tqdm(
-            map_fn(partial(_safe_likelihood_call, this_logl), dict_samples[starting_index:], chunksize=chunksize),
+            map_fn(likelihood_fn, dict_samples[starting_index:]),
             desc='Computing likelihoods',
             total=n,
         ))

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -253,10 +253,9 @@ def get_weights_for_reweighting(
             else:
                 chunksize = max(100, n // (2 * npool))
                 map_fn = partial(my_pool.imap, chunksize=chunksize)
-            likelihood_fn = partial(_safe_likelihood_call, this_logl)
 
             log_l = list(tqdm(
-                map_fn(likelihood_fn, dict_samples[starting_index:]),
+                map_fn(this_logl.log_likelihood, dict_samples[starting_index:]),
                 desc='Computing likelihoods',
                 total=n,
             ))

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -9,6 +9,7 @@ from copy import copy
 from importlib import import_module
 from itertools import product
 import multiprocessing
+from functools import partial
 import numpy as np
 import pandas as pd
 import scipy.stats
@@ -31,6 +32,11 @@ from .prior import Prior, PriorDict, DeltaFunction, ConditionalDeltaFunction
 
 
 EXTENSIONS = ["json", "hdf5", "h5", "pickle", "pkl"]
+
+
+def __eval_l(likelihood, params):
+    likelihood.parameters.update(params)
+    return likelihood.log_likelihood()
 
 
 def result_file_name(outdir, label, extension='json', gzip=False):
@@ -191,7 +197,7 @@ def read_in_result_list(filename_list, invalid="warning"):
 
 def get_weights_for_reweighting(
         result, new_likelihood=None, new_prior=None, old_likelihood=None,
-        old_prior=None, resume_file=None, n_checkpoint=5000, npool=1):
+        old_prior=None, resume_file=None, n_checkpoint=5000, npool=1, pool=None):
     """ Calculate the weights for reweight()
 
     See bilby.core.result.reweight() for help with the inputs
@@ -234,8 +240,7 @@ def get_weights_for_reweighting(
         basedir = os.path.split(resume_file)[0]
         check_directory_exists_and_if_not_mkdir(basedir)
 
-    dict_samples = [{key: sample[key] for key in result.posterior}
-                    for _, sample in result.posterior.iterrows()]
+    dict_samples = result.posterior.to_dict(orient="records")
     n = len(dict_samples) - starting_index
 
     # Helper function to compute likelihoods in parallel
@@ -243,11 +248,8 @@ def get_weights_for_reweighting(
         with multiprocessing.Pool(processes=npool) as pool:
             chunksize = max(100, n // (2 * npool))
             return list(tqdm(
-                pool.imap(
-                    this_logl.log_likelihood,
-                    dict_samples[starting_index:],
-                    chunksize=chunksize,
-                ),
+                pool.imap(partial(__eval_l, this_logl),
+                        dict_samples[starting_index:], chunksize=chunksize),
                 desc='Computing likelihoods',
                 total=n)
             )
@@ -321,7 +323,7 @@ def rejection_sample(posterior, weights):
 def reweight(result, label=None, new_likelihood=None, new_prior=None,
              old_likelihood=None, old_prior=None, conversion_function=None, npool=1,
              verbose_output=False, resume_file=None, n_checkpoint=5000,
-             use_nested_samples=False):
+             use_nested_samples=False, pool=None):
     """ Reweight a result to a new likelihood/prior using rejection sampling
 
     Parameters
@@ -384,7 +386,9 @@ def reweight(result, label=None, new_likelihood=None, new_prior=None,
         get_weights_for_reweighting(
             result, new_likelihood=new_likelihood, new_prior=new_prior,
             old_likelihood=old_likelihood, old_prior=old_prior,
-            resume_file=resume_file, n_checkpoint=n_checkpoint, npool=npool)
+            resume_file=resume_file, n_checkpoint=n_checkpoint,
+            npool=npool, pool=pool,
+        )
 
     if use_nested_samples:
         ln_weights += np.log(result.posterior["weights"])
@@ -411,10 +415,14 @@ def reweight(result, label=None, new_likelihood=None, new_prior=None,
 
     if conversion_function is not None:
         data_frame = result.posterior
-        if "npool" in inspect.signature(conversion_function).parameters:
-            data_frame = conversion_function(data_frame, new_likelihood, new_prior, npool=npool)
-        else:
-            data_frame = conversion_function(data_frame, new_likelihood, new_prior)
+        parameters = inspect.signature(conversion_function).parameters
+        kwargs = dict()
+        for key, value in [
+            ("likelihood", new_likelihood), ("priors", new_prior), ("npool", npool), ("pool", pool)
+        ]:
+            if key in parameters:
+                kwargs[key] = value
+        data_frame = conversion_function(data_frame, **kwargs)
         result.posterior = data_frame
 
     if label:
@@ -754,6 +762,21 @@ class Result(object):
     @property
     def log_10_noise_evidence(self):
         return self.log_noise_evidence / np.log(10)
+
+    @property
+    def sampler_kwargs(self):
+        return self._sampler_kwargs
+
+    @sampler_kwargs.setter
+    def sampler_kwargs(self, sampler_kwargs):
+        if sampler_kwargs is None:
+            sampler_kwargs = dict()
+        else:
+            sampler_kwargs = copy(sampler_kwargs)
+        if "pool" in sampler_kwargs:
+            # pool objects can't be neatly serialized
+            sampler_kwargs["pool"] = None
+        self._sampler_kwargs = sampler_kwargs
 
     @property
     def version(self):
@@ -1520,7 +1543,7 @@ class Result(object):
         return posterior
 
     def samples_to_posterior(self, likelihood=None, priors=None,
-                             conversion_function=None, npool=1):
+                             conversion_function=None, npool=1, pool=None):
         """
         Convert array of samples to posterior (a Pandas data frame)
 
@@ -1550,10 +1573,14 @@ class Result(object):
             data_frame['log_prior'] = self.log_prior_evaluations
 
         if conversion_function is not None:
-            if "npool" in inspect.signature(conversion_function).parameters:
-                data_frame = conversion_function(data_frame, likelihood, priors, npool=npool)
-            else:
-                data_frame = conversion_function(data_frame, likelihood, priors)
+            parameters = inspect.signature(conversion_function).parameters
+            kwargs = dict()
+            for key, value in [
+                ("likelihood", likelihood), ("priors", priors), ("npool", npool), ("pool", pool)
+            ]:
+                if key in parameters:
+                    kwargs[key] = value
+            data_frame = conversion_function(data_frame, **kwargs)
         self.posterior = data_frame
 
     def calculate_prior_values(self, priors):

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -245,22 +245,21 @@ def get_weights_for_reweighting(
 
     # Helper function to compute likelihoods in parallel
     def eval_pool(this_logl):
-        from .utils.parallel import create_pool, close_pool
+        from .utils.parallel import bilby_pool
 
         chunksize = max(100, n // (2 * npool))
-        my_pool = create_pool(likelihood=this_logl, npool=npool)
-        if my_pool is None:
-            map_fn = map
-        else:
-            map_fn = partial(my_pool.imap, chunksize=chunksize)
-        likelihood_fn = partial(_safe_likelihood_call, this_logl)
+        with bilby_pool(likelihood=this_logl, npool=npool) as my_pool:
+            if my_pool is None:
+                map_fn = map
+            else:
+                map_fn = partial(my_pool.imap, chunksize=chunksize)
+            likelihood_fn = partial(_safe_likelihood_call, this_logl)
 
-        log_l = list(tqdm(
-            map_fn(likelihood_fn, dict_samples[starting_index:]),
-            desc='Computing likelihoods',
-            total=n,
-        ))
-        close_pool(my_pool)
+            log_l = list(tqdm(
+                map_fn(likelihood_fn, dict_samples[starting_index:]),
+                desc='Computing likelihoods',
+                total=n,
+            ))
         return log_l
 
     if old_likelihood is None:

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -8,8 +8,8 @@ from collections import namedtuple
 from copy import copy
 from importlib import import_module
 from itertools import product
-import multiprocessing
 from functools import partial
+
 import numpy as np
 import pandas as pd
 import scipy.stats
@@ -245,14 +245,22 @@ def get_weights_for_reweighting(
 
     # Helper function to compute likelihoods in parallel
     def eval_pool(this_logl):
-        with multiprocessing.Pool(processes=npool) as pool:
-            chunksize = max(100, n // (2 * npool))
-            return list(tqdm(
-                pool.imap(partial(__eval_l, this_logl),
-                        dict_samples[starting_index:], chunksize=chunksize),
-                desc='Computing likelihoods',
-                total=n)
-            )
+        from .utils.parallel import create_pool, close_pool
+
+        chunksize = max(100, n // (2 * npool))
+        my_pool = create_pool(likelihood=this_logl, npool=npool)
+        if my_pool is None:
+            map_fn = map
+        else:
+            map_fn = my_pool.imap
+
+        log_l = list(tqdm(
+            map_fn(partial(_safe_likelihood_call, this_logl), dict_samples[starting_index:], chunksize=chunksize),
+            desc='Computing likelihoods',
+            total=n,
+        ))
+        close_pool(my_pool)
+        return log_l
 
     if old_likelihood is None:
         old_log_likelihood_array[starting_index:] = \

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -8,7 +8,8 @@ from collections import namedtuple
 from copy import copy
 from importlib import import_module
 from itertools import product
-import multiprocessing
+from functools import partial
+
 import numpy as np
 import pandas as pd
 import scipy.stats
@@ -31,6 +32,11 @@ from .prior import Prior, PriorDict, DeltaFunction, ConditionalDeltaFunction
 
 
 EXTENSIONS = ["json", "hdf5", "h5", "pickle", "pkl"]
+
+
+def __eval_l(likelihood, params):
+    likelihood.parameters.update(params)
+    return likelihood.log_likelihood()
 
 
 def result_file_name(outdir, label, extension='json', gzip=False):
@@ -191,7 +197,7 @@ def read_in_result_list(filename_list, invalid="warning"):
 
 def get_weights_for_reweighting(
         result, new_likelihood=None, new_prior=None, old_likelihood=None,
-        old_prior=None, resume_file=None, n_checkpoint=5000, npool=1):
+        old_prior=None, resume_file=None, n_checkpoint=5000, npool=1, pool=None):
     """ Calculate the weights for reweight()
 
     See bilby.core.result.reweight() for help with the inputs
@@ -234,23 +240,26 @@ def get_weights_for_reweighting(
         basedir = os.path.split(resume_file)[0]
         check_directory_exists_and_if_not_mkdir(basedir)
 
-    dict_samples = [{key: sample[key] for key in result.posterior}
-                    for _, sample in result.posterior.iterrows()]
+    dict_samples = result.posterior.to_dict(orient="records")
     n = len(dict_samples) - starting_index
 
     # Helper function to compute likelihoods in parallel
     def eval_pool(this_logl):
-        with multiprocessing.Pool(processes=npool) as pool:
-            chunksize = max(100, n // (2 * npool))
-            return list(tqdm(
-                pool.imap(
-                    this_logl.log_likelihood,
-                    dict_samples[starting_index:],
-                    chunksize=chunksize,
-                ),
+        from .utils.parallel import bilby_pool
+
+        with bilby_pool(likelihood=this_logl, npool=npool) as my_pool:
+            if my_pool is None:
+                map_fn = map
+            else:
+                chunksize = max(100, n // (2 * npool))
+                map_fn = partial(my_pool.imap, chunksize=chunksize)
+
+            log_l = list(tqdm(
+                map_fn(this_logl.log_likelihood, dict_samples[starting_index:]),
                 desc='Computing likelihoods',
-                total=n)
-            )
+                total=n,
+            ))
+        return log_l
 
     if old_likelihood is None:
         old_log_likelihood_array[starting_index:] = \
@@ -324,7 +333,7 @@ def rejection_sample(posterior, weights):
 def reweight(result, label=None, new_likelihood=None, new_prior=None,
              old_likelihood=None, old_prior=None, conversion_function=None, npool=1,
              verbose_output=False, resume_file=None, n_checkpoint=5000,
-             use_nested_samples=False):
+             use_nested_samples=False, pool=None):
     """ Reweight a result to a new likelihood/prior using rejection sampling
 
     Parameters
@@ -387,7 +396,9 @@ def reweight(result, label=None, new_likelihood=None, new_prior=None,
         get_weights_for_reweighting(
             result, new_likelihood=new_likelihood, new_prior=new_prior,
             old_likelihood=old_likelihood, old_prior=old_prior,
-            resume_file=resume_file, n_checkpoint=n_checkpoint, npool=npool)
+            resume_file=resume_file, n_checkpoint=n_checkpoint,
+            npool=npool, pool=pool,
+        )
 
     if use_nested_samples:
         ln_weights += np.log(result.posterior["weights"])
@@ -414,10 +425,14 @@ def reweight(result, label=None, new_likelihood=None, new_prior=None,
 
     if conversion_function is not None:
         data_frame = result.posterior
-        if "npool" in inspect.signature(conversion_function).parameters:
-            data_frame = conversion_function(data_frame, new_likelihood, new_prior, npool=npool)
-        else:
-            data_frame = conversion_function(data_frame, new_likelihood, new_prior)
+        parameters = inspect.signature(conversion_function).parameters
+        kwargs = dict()
+        for key, value in [
+            ("likelihood", new_likelihood), ("priors", new_prior), ("npool", npool), ("pool", pool)
+        ]:
+            if key in parameters:
+                kwargs[key] = value
+        data_frame = conversion_function(data_frame, **kwargs)
         result.posterior = data_frame
 
     if label:
@@ -757,6 +772,21 @@ class Result(object):
     @property
     def log_10_noise_evidence(self):
         return self.log_noise_evidence / np.log(10)
+
+    @property
+    def sampler_kwargs(self):
+        return self._sampler_kwargs
+
+    @sampler_kwargs.setter
+    def sampler_kwargs(self, sampler_kwargs):
+        if sampler_kwargs is None:
+            sampler_kwargs = dict()
+        else:
+            sampler_kwargs = copy(sampler_kwargs)
+        if "pool" in sampler_kwargs:
+            # pool objects can't be neatly serialized
+            sampler_kwargs["pool"] = None
+        self._sampler_kwargs = sampler_kwargs
 
     @property
     def version(self):
@@ -1523,7 +1553,7 @@ class Result(object):
         return posterior
 
     def samples_to_posterior(self, likelihood=None, priors=None,
-                             conversion_function=None, npool=1):
+                             conversion_function=None, npool=1, pool=None):
         """
         Convert array of samples to posterior (a Pandas data frame)
 
@@ -1553,10 +1583,14 @@ class Result(object):
             data_frame['log_prior'] = self.log_prior_evaluations
 
         if conversion_function is not None:
-            if "npool" in inspect.signature(conversion_function).parameters:
-                data_frame = conversion_function(data_frame, likelihood, priors, npool=npool)
-            else:
-                data_frame = conversion_function(data_frame, likelihood, priors)
+            parameters = inspect.signature(conversion_function).parameters
+            kwargs = dict()
+            for key, value in [
+                ("likelihood", likelihood), ("priors", priors), ("npool", npool), ("pool", pool)
+            ]:
+                if key in parameters:
+                    kwargs[key] = value
+            data_frame = conversion_function(data_frame, **kwargs)
         self.posterior = data_frame
 
     def calculate_prior_values(self, priors):

--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -11,6 +11,7 @@ from ..utils import (
     loaded_modules_dict,
     logger,
 )
+from ..utils.parallel import bilby_pool
 from . import proposal
 from .base_sampler import Sampler, SamplingMarginalisedParameterError
 
@@ -171,6 +172,7 @@ def run_sampler(
     gzip=False,
     result_class=None,
     npool=1,
+    pool=None,
     **kwargs,
 ):
     """
@@ -279,36 +281,27 @@ def run_sampler(
 
         likelihood = ZeroLikelihood(likelihood)
 
+    common_kwargs = dict(
+        likelihood=likelihood,
+        priors=priors,
+        outdir=outdir,
+        label=label,
+        injection_parameters=injection_parameters,
+        meta_data=meta_data,
+        use_ratio=use_ratio,
+        plot=plot,
+        result_class=result_class,
+        npool=npool,
+        pool=pool,
+    )
+
     if isinstance(sampler, Sampler):
         pass
     elif isinstance(sampler, str):
         sampler_class = get_sampler_class(sampler)
-        sampler = sampler_class(
-            likelihood,
-            priors=priors,
-            outdir=outdir,
-            label=label,
-            injection_parameters=injection_parameters,
-            meta_data=meta_data,
-            use_ratio=use_ratio,
-            plot=plot,
-            result_class=result_class,
-            npool=npool,
-            **kwargs,
-        )
+        sampler = sampler_class(**common_kwargs, **kwargs)
     elif inspect.isclass(sampler):
-        sampler = sampler.__init__(
-            likelihood,
-            priors=priors,
-            outdir=outdir,
-            label=label,
-            use_ratio=use_ratio,
-            plot=plot,
-            injection_parameters=injection_parameters,
-            meta_data=meta_data,
-            npool=npool,
-            **kwargs,
-        )
+        sampler = sampler.__init__(**common_kwargs, **kwargs)
     else:
         raise ValueError(
             "Provided sampler should be a Sampler object or name of a known "
@@ -318,42 +311,81 @@ def run_sampler(
     if sampler.cached_result:
         logger.warning("Using cached result")
         result = sampler.cached_result
+        result = apply_conversion_function(
+            result=result,
+            likelihood=likelihood,
+            conversion_function=conversion_function,
+            npool=npool,
+            pool=pool,
+        )
     else:
         # Run the sampler
-        start_time = datetime.datetime.now()
-        if command_line_args.bilby_test_mode:
-            result = sampler._run_test()
-        else:
-            result = sampler.run_sampler()
-        end_time = datetime.datetime.now()
-
-        # Some samplers calculate the sampling time internally
-        if result.sampling_time is None:
-            result.sampling_time = end_time - start_time
-        elif isinstance(result.sampling_time, (float, int)):
-            result.sampling_time = datetime.timedelta(result.sampling_time)
-
-        logger.info(f"Sampling time: {result.sampling_time}")
-        # Convert sampling time into seconds
-        result.sampling_time = result.sampling_time.total_seconds()
-
-        if sampler.use_ratio:
-            result.log_noise_evidence = likelihood.noise_log_likelihood()
-            result.log_bayes_factor = result.log_evidence
-            result.log_evidence = result.log_bayes_factor + result.log_noise_evidence
-        else:
-            result.log_noise_evidence = likelihood.noise_log_likelihood()
-            result.log_bayes_factor = result.log_evidence - result.log_noise_evidence
-
-        if None not in [result.injection_parameters, conversion_function]:
-            result.injection_parameters = conversion_function(
-                result.injection_parameters
+        with bilby_pool(
+            likelihood,
+            priors,
+            use_ratio=sampler.use_ratio,
+            search_parameter_keys=sampler.search_parameter_keys,
+            npool=npool,
+            pool=pool,
+            parameters=priors.sample(),
+        ) as _pool:
+            start_time = datetime.datetime.now()
+            sampler.pool = _pool
+            if command_line_args.bilby_test_mode:
+                result = sampler._run_test()
+            else:
+                result = sampler.run_sampler()
+            end_time = datetime.datetime.now()
+            result = finalize_result(
+                result=result,
+                likelihood=likelihood,
+                use_ratio=sampler.use_ratio,
+                start_time=start_time,
+                end_time=end_time,
             )
 
-        # Initial save of the sampler in case of failure in samples_to_posterior
-        if save:
-            result.save_to_file(extension=save, gzip=gzip, outdir=outdir)
+            # Initial save of the sampler in case of failure in samples_to_posterior
+            if save:
+                result.save_to_file(extension=save, gzip=gzip, outdir=outdir)
 
+            result = apply_conversion_function(
+                result=result,
+                likelihood=likelihood,
+                conversion_function=conversion_function,
+                npool=npool,
+                pool=_pool,
+            )
+
+    if save:
+        # The overwrite here ensures we overwrite the initially stored data
+        result.save_to_file(overwrite=True, extension=save, gzip=gzip, outdir=outdir)
+
+    if plot:
+        result.plot_corner()
+    logger.info(f"Summary of results:\n{result}")
+    return result
+
+
+def apply_conversion_function(
+    result, likelihood, conversion_function, npool=None, pool=None
+):
+    """
+    Apply the conversion function to the injected parameters and posterior if the
+    posterior has not already been created from the stored samples.
+
+    Parameters
+    ----------
+    result : bilby.core.result.Result
+        The result object from the sampler.
+    likelihood : bilby.Likelihood
+        The likelihood used during sampling.
+    conversion_function : function
+        The conversion function to apply.
+    npool : int, optional
+        The number of processes to use in a processing pool.
+    pool : multiprocessing.Pool, schwimmbad.MPIPool, optional
+        The pool to use for parallelisation, this overrides the :code:`npool` argument.
+    """
     if None not in [result.injection_parameters, conversion_function]:
         result.injection_parameters = conversion_function(
             result.injection_parameters,
@@ -367,15 +399,30 @@ def run_sampler(
             priors=result.priors,
             conversion_function=conversion_function,
             npool=npool,
+            pool=pool,
         )
+    return result
 
-    if save:
-        # The overwrite here ensures we overwrite the initially stored data
-        result.save_to_file(overwrite=True, extension=save, gzip=gzip, outdir=outdir)
 
-    if plot:
-        result.plot_corner()
-    logger.info(f"Summary of results:\n{result}")
+def finalize_result(result, likelihood, use_ratio, start_time=None, end_time=None):
+    # Some samplers calculate the sampling time internally
+    if result.sampling_time is None and None not in [start_time, end_time]:
+        result.sampling_time = end_time - start_time
+    elif isinstance(result.sampling_time, (float, int)):
+        result.sampling_time = datetime.timedelta(result.sampling_time)
+
+    logger.info(f"Sampling time: {result.sampling_time}")
+    # Convert sampling time into seconds
+    result.sampling_time = result.sampling_time.total_seconds()
+
+    if use_ratio:
+        result.log_noise_evidence = likelihood.noise_log_likelihood()
+        result.log_bayes_factor = result.log_evidence
+        result.log_evidence = result.log_bayes_factor + result.log_noise_evidence
+    else:
+        result.log_noise_evidence = likelihood.noise_log_likelihood()
+        result.log_bayes_factor = result.log_evidence - result.log_noise_evidence
+
     return result
 
 

--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -11,9 +11,9 @@ from ..utils import (
     loaded_modules_dict,
     logger,
 )
+from ..utils.parallel import bilby_pool
 from . import proposal
 from .base_sampler import Sampler, SamplingMarginalisedParameterError
-from ..utils.parallel import bilby_pool
 
 
 class ImplementedSamplers:
@@ -281,7 +281,7 @@ def run_sampler(
 
         likelihood = ZeroLikelihood(likelihood)
 
-    common_kwargs =dict(
+    common_kwargs = dict(
         likelihood=likelihood,
         priors=priors,
         outdir=outdir,
@@ -337,7 +337,11 @@ def run_sampler(
                 result = sampler.run_sampler()
             end_time = datetime.datetime.now()
             result = finalize_result(
-                result=result, likelihood=likelihood, start_time=start_time, end_time=end_time
+                result=result,
+                likelihood=likelihood,
+                use_ratio=sampler.use_ratio,
+                start_time=start_time,
+                end_time=end_time,
             )
 
             # Initial save of the sampler in case of failure in samples_to_posterior
@@ -362,7 +366,9 @@ def run_sampler(
     return result
 
 
-def apply_conversion_function(result, likelihood, conversion_function, npool=None, pool=None):
+def apply_conversion_function(
+    result, likelihood, conversion_function, npool=None, pool=None
+):
     """
     Apply the conversion function to the injected parameters and posterior if the
     posterior has not already been created from the stored samples.
@@ -398,7 +404,7 @@ def apply_conversion_function(result, likelihood, conversion_function, npool=Non
     return result
 
 
-def finalize_result(result, likelihood, start_time=None, end_time=None):
+def finalize_result(result, likelihood, use_ratio, start_time=None, end_time=None):
     # Some samplers calculate the sampling time internally
     if result.sampling_time is None and None not in [start_time, end_time]:
         result.sampling_time = end_time - start_time
@@ -409,7 +415,7 @@ def finalize_result(result, likelihood, start_time=None, end_time=None):
     # Convert sampling time into seconds
     result.sampling_time = result.sampling_time.total_seconds()
 
-    if sampler.use_ratio:
+    if use_ratio:
         result.log_noise_evidence = likelihood.noise_log_likelihood()
         result.log_bayes_factor = result.log_evidence
         result.log_evidence = result.log_bayes_factor + result.log_noise_evidence

--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -13,6 +13,7 @@ from ..utils import (
 )
 from . import proposal
 from .base_sampler import Sampler, SamplingMarginalisedParameterError
+from ..utils.parallel import bilby_pool
 
 
 class ImplementedSamplers:
@@ -280,38 +281,27 @@ def run_sampler(
 
         likelihood = ZeroLikelihood(likelihood)
 
+    common_kwargs =dict(
+        likelihood=likelihood,
+        priors=priors,
+        outdir=outdir,
+        label=label,
+        injection_parameters=injection_parameters,
+        meta_data=meta_data,
+        use_ratio=use_ratio,
+        plot=plot,
+        result_class=result_class,
+        npool=npool,
+        pool=pool,
+    )
+
     if isinstance(sampler, Sampler):
         pass
     elif isinstance(sampler, str):
         sampler_class = get_sampler_class(sampler)
-        sampler = sampler_class(
-            likelihood,
-            priors=priors,
-            outdir=outdir,
-            label=label,
-            injection_parameters=injection_parameters,
-            meta_data=meta_data,
-            use_ratio=use_ratio,
-            plot=plot,
-            result_class=result_class,
-            npool=npool,
-            pool=pool,
-            **kwargs,
-        )
+        sampler = sampler_class(**common_kwargs, **kwargs)
     elif inspect.isclass(sampler):
-        sampler = sampler.__init__(
-            likelihood,
-            priors=priors,
-            outdir=outdir,
-            label=label,
-            use_ratio=use_ratio,
-            plot=plot,
-            injection_parameters=injection_parameters,
-            meta_data=meta_data,
-            npool=npool,
-            pool=pool,
-            **kwargs,
-        )
+        sampler = sampler.__init__(**common_kwargs, **kwargs)
     else:
         raise ValueError(
             "Provided sampler should be a Sampler object or name of a known "
@@ -321,10 +311,15 @@ def run_sampler(
     if sampler.cached_result:
         logger.warning("Using cached result")
         result = sampler.cached_result
+        result = apply_conversion_function(
+            result=result,
+            likelihood=likelihood,
+            conversion_function=conversion_function,
+            npool=npool,
+            pool=pool,
+        )
     else:
         # Run the sampler
-        start_time = datetime.datetime.now()
-        from ..utils.parallel import bilby_pool
         with bilby_pool(
             likelihood,
             priors,
@@ -332,60 +327,26 @@ def run_sampler(
             search_parameter_keys=sampler.search_parameter_keys,
             npool=npool,
             pool=pool,
+            parameters=priors.sample(),
         ) as _pool:
+            start_time = datetime.datetime.now()
             sampler.pool = _pool
             if command_line_args.bilby_test_mode:
                 result = sampler._run_test()
             else:
                 result = sampler.run_sampler()
-        end_time = datetime.datetime.now()
-
-        # Some samplers calculate the sampling time internally
-        if result.sampling_time is None:
-            result.sampling_time = end_time - start_time
-        elif isinstance(result.sampling_time, (float, int)):
-            result.sampling_time = datetime.timedelta(result.sampling_time)
-
-        logger.info(f"Sampling time: {result.sampling_time}")
-        # Convert sampling time into seconds
-        result.sampling_time = result.sampling_time.total_seconds()
-
-        if sampler.use_ratio:
-            result.log_noise_evidence = likelihood.noise_log_likelihood()
-            result.log_bayes_factor = result.log_evidence
-            result.log_evidence = result.log_bayes_factor + result.log_noise_evidence
-        else:
-            result.log_noise_evidence = likelihood.noise_log_likelihood()
-            result.log_bayes_factor = result.log_evidence - result.log_noise_evidence
-
-        if None not in [result.injection_parameters, conversion_function]:
-            result.injection_parameters = conversion_function(
-                result.injection_parameters
+            end_time = datetime.datetime.now()
+            result = finalize_result(
+                result=result, likelihood=likelihood, start_time=start_time, end_time=end_time
             )
 
-        # Initial save of the sampler in case of failure in samples_to_posterior
-        if save:
-            result.save_to_file(extension=save, gzip=gzip, outdir=outdir)
+            # Initial save of the sampler in case of failure in samples_to_posterior
+            if save:
+                result.save_to_file(extension=save, gzip=gzip, outdir=outdir)
 
-    if None not in [result.injection_parameters, conversion_function]:
-        result.injection_parameters = conversion_function(
-            result.injection_parameters,
-            likelihood=likelihood,
-        )
-
-    # Check if the posterior has already been created
-    if getattr(result, "_posterior", None) is None:
-        with bilby_pool(
-            likelihood,
-            priors,
-            use_ratio=sampler.use_ratio,
-            search_parameter_keys=sampler.search_parameter_keys,
-            npool=npool,
-            pool=pool,
-        ) as _pool:
-            result.samples_to_posterior(
+            result = apply_conversion_function(
+                result=result,
                 likelihood=likelihood,
-                priors=result.priors,
                 conversion_function=conversion_function,
                 npool=npool,
                 pool=_pool,
@@ -398,6 +359,64 @@ def run_sampler(
     if plot:
         result.plot_corner()
     logger.info(f"Summary of results:\n{result}")
+    return result
+
+
+def apply_conversion_function(result, likelihood, conversion_function, npool=None, pool=None):
+    """
+    Apply the conversion function to the injected parameters and posterior if the
+    posterior has not already been created from the stored samples.
+
+    Parameters
+    ----------
+    result : bilby.core.result.Result
+        The result object from the sampler.
+    likelihood : bilby.Likelihood
+        The likelihood used during sampling.
+    conversion_function : function
+        The conversion function to apply.
+    npool : int, optional
+        The number of processes to use in a processing pool.
+    pool : multiprocessing.Pool, schwimmbad.MPIPool, optional
+        The pool to use for parallelisation, this overrides the :code:`npool` argument.
+    """
+    if None not in [result.injection_parameters, conversion_function]:
+        result.injection_parameters = conversion_function(
+            result.injection_parameters,
+            likelihood=likelihood,
+        )
+
+    # Check if the posterior has already been created
+    if getattr(result, "_posterior", None) is None:
+        result.samples_to_posterior(
+            likelihood=likelihood,
+            priors=result.priors,
+            conversion_function=conversion_function,
+            npool=npool,
+            pool=pool,
+        )
+    return result
+
+
+def finalize_result(result, likelihood, start_time=None, end_time=None):
+    # Some samplers calculate the sampling time internally
+    if result.sampling_time is None and None not in [start_time, end_time]:
+        result.sampling_time = end_time - start_time
+    elif isinstance(result.sampling_time, (float, int)):
+        result.sampling_time = datetime.timedelta(result.sampling_time)
+
+    logger.info(f"Sampling time: {result.sampling_time}")
+    # Convert sampling time into seconds
+    result.sampling_time = result.sampling_time.total_seconds()
+
+    if sampler.use_ratio:
+        result.log_noise_evidence = likelihood.noise_log_likelihood()
+        result.log_bayes_factor = result.log_evidence
+        result.log_evidence = result.log_bayes_factor + result.log_noise_evidence
+    else:
+        result.log_noise_evidence = likelihood.noise_log_likelihood()
+        result.log_bayes_factor = result.log_evidence - result.log_noise_evidence
+
     return result
 
 

--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -171,6 +171,7 @@ def run_sampler(
     gzip=False,
     result_class=None,
     npool=1,
+    pool=None,
     **kwargs,
 ):
     """
@@ -294,6 +295,7 @@ def run_sampler(
             plot=plot,
             result_class=result_class,
             npool=npool,
+            pool=pool,
             **kwargs,
         )
     elif inspect.isclass(sampler):
@@ -307,6 +309,7 @@ def run_sampler(
             injection_parameters=injection_parameters,
             meta_data=meta_data,
             npool=npool,
+            pool=pool,
             **kwargs,
         )
     else:
@@ -321,10 +324,20 @@ def run_sampler(
     else:
         # Run the sampler
         start_time = datetime.datetime.now()
-        if command_line_args.bilby_test_mode:
-            result = sampler._run_test()
-        else:
-            result = sampler.run_sampler()
+        from ..utils.parallel import bilby_pool
+        with bilby_pool(
+            likelihood,
+            priors,
+            use_ratio=sampler.use_ratio,
+            search_parameter_keys=sampler.search_parameter_keys,
+            npool=npool,
+            pool=pool,
+        ) as _pool:
+            sampler.pool = _pool
+            if command_line_args.bilby_test_mode:
+                result = sampler._run_test()
+            else:
+                result = sampler.run_sampler()
         end_time = datetime.datetime.now()
 
         # Some samplers calculate the sampling time internally
@@ -362,12 +375,21 @@ def run_sampler(
 
     # Check if the posterior has already been created
     if getattr(result, "_posterior", None) is None:
-        result.samples_to_posterior(
-            likelihood=likelihood,
-            priors=result.priors,
-            conversion_function=conversion_function,
+        with bilby_pool(
+            likelihood,
+            priors,
+            use_ratio=sampler.use_ratio,
+            search_parameter_keys=sampler.search_parameter_keys,
             npool=npool,
-        )
+            pool=pool,
+        ) as _pool:
+            result.samples_to_posterior(
+                likelihood=likelihood,
+                priors=result.priors,
+                conversion_function=conversion_function,
+                npool=npool,
+                pool=_pool,
+            )
 
     if save:
         # The overwrite here ensures we overwrite the initially stored data

--- a/bilby/core/sampler/base_sampler.py
+++ b/bilby/core/sampler/base_sampler.py
@@ -764,9 +764,8 @@ class Sampler(object):
                 sys.exit(self.exit_code)
 
     def _close_pool(self):
-        if (
-            getattr(self, "pool", None) is not None
-            and not getattr(self, "_user_pool", True)
+        if getattr(self, "pool", None) is not None and not getattr(
+            self, "_user_pool", True
         ):
             logger.info("Starting to close worker pool.")
             close_pool(self.pool)
@@ -775,11 +774,14 @@ class Sampler(object):
             logger.info("Finished closing worker pool.")
 
     def _setup_pool(self):
+        parameters = self.priors.sample()
+
         if hasattr(self.pool, "map"):
             self._user_pool = True
+        elif self.npool in (1, None):
+            self._user_pool = False
         else:
             self._user_pool = False
-            parameters = self.priors.sample()
             self.pool = create_pool(
                 likelihood=self.likelihood,
                 priors=self.priors,

--- a/bilby/core/sampler/base_sampler.py
+++ b/bilby/core/sampler/base_sampler.py
@@ -233,6 +233,7 @@ class Sampler(object):
         soft_init=False,
         exit_code=130,
         npool=1,
+        pool=None,
         **kwargs,
     ):
         self.likelihood = likelihood
@@ -246,6 +247,7 @@ class Sampler(object):
         self.injection_parameters = injection_parameters
         self.meta_data = meta_data
         self.use_ratio = use_ratio
+        self.pool = pool
         self._npool = npool
         if not skip_import_verification:
             self._verify_external_sampler()
@@ -761,35 +763,33 @@ class Sampler(object):
                 sys.exit(self.exit_code)
 
     def _close_pool(self):
-        if getattr(self, "pool", None) is not None:
+        if (
+            getattr(self, "pool", None) is not None
+            and not getattr(self, "_user_pool", True)
+        ):
+            from ..utils.parallel import close_pool
             logger.info("Starting to close worker pool.")
-            self.pool.close()
-            self.pool.join()
+            close_pool(self.pool)
             self.pool = None
             self.kwargs["pool"] = self.pool
             logger.info("Finished closing worker pool.")
 
     def _setup_pool(self):
-        if self.kwargs.get("pool", None) is not None:
-            logger.info("Using user defined pool.")
-            self.pool = self.kwargs["pool"]
-        elif self.npool is not None and self.npool > 1:
-            logger.info(f"Setting up multiproccesing pool with {self.npool} processes")
-            import multiprocessing
+        from ..utils.parallel import create_pool
 
-            self.pool = multiprocessing.Pool(
-                processes=self.npool,
-                initializer=_initialize_global_variables,
-                initargs=(
-                    self.likelihood,
-                    self.priors,
-                    self._search_parameter_keys,
-                    self.use_ratio,
-                    deepcopy(self.parameters),
-                ),
-            )
+        if hasattr(self.pool, "map"):
+            self._user_pool = True
         else:
-            self.pool = None
+            self._user_pool = False
+
+        self.pool = create_pool(
+            likelihood=self.likelihood,
+            priors=self.priors,
+            search_parameter_keys=self._search_parameter_keys,
+            use_ratio=self.use_ratio,
+            npool=self.npool,
+            pool=self.pool,
+        )
         _initialize_global_variables(
             likelihood=self.likelihood,
             priors=self.priors,

--- a/bilby/core/sampler/base_sampler.py
+++ b/bilby/core/sampler/base_sampler.py
@@ -19,6 +19,7 @@ from ..utils import (
     command_line_args,
     logger,
 )
+from ..utils.parallel import close_pool, create_pool
 from ..utils.random import seed as set_seed
 
 
@@ -767,7 +768,6 @@ class Sampler(object):
             getattr(self, "pool", None) is not None
             and not getattr(self, "_user_pool", True)
         ):
-            from ..utils.parallel import close_pool
             logger.info("Starting to close worker pool.")
             close_pool(self.pool)
             self.pool = None
@@ -775,27 +775,31 @@ class Sampler(object):
             logger.info("Finished closing worker pool.")
 
     def _setup_pool(self):
-        from ..utils.parallel import create_pool
-
         if hasattr(self.pool, "map"):
             self._user_pool = True
         else:
             self._user_pool = False
-
-        self.pool = create_pool(
-            likelihood=self.likelihood,
-            priors=self.priors,
-            search_parameter_keys=self._search_parameter_keys,
-            use_ratio=self.use_ratio,
-            npool=self.npool,
-            pool=self.pool,
-        )
+            parameters = self.priors.sample()
+            self.pool = create_pool(
+                likelihood=self.likelihood,
+                priors=self.priors,
+                search_parameter_keys=self._search_parameter_keys,
+                use_ratio=self.use_ratio,
+                npool=self.npool,
+                pool=self.pool,
+                parameters=parameters,
+            )
+            if self.pool is not None:
+                logger.warning(
+                    "Setting up parallel pool in sampler is deprecated. Use "
+                    "bilby.utils.parallel.bilby_pool context instead."
+                )
         _initialize_global_variables(
             likelihood=self.likelihood,
             priors=self.priors,
             search_parameter_keys=self._search_parameter_keys,
             use_ratio=self.use_ratio,
-            parameters=deepcopy(self.parameters),
+            parameters=parameters,
         )
         self.kwargs["pool"] = self.pool
 

--- a/bilby/core/sampler/base_sampler.py
+++ b/bilby/core/sampler/base_sampler.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 from copy import deepcopy
 
-import attr
 import numpy as np
 from pandas import DataFrame
 
@@ -18,52 +17,13 @@ from ..utils import (
     command_line_args,
     logger,
 )
+from ..utils.parallel import (
+    close_pool,
+    create_pool,
+    initialize_global_variables,
+    sampling_convenience_dump,
+)
 from ..utils.random import seed as set_seed
-
-
-@attr.s
-class _SamplingContainer:
-    """
-    A container class for objects that are stored independently in each thread
-    for some samplers.
-
-    A single instance of this will appear in this module that can be access
-    by the individual samplers.
-
-    This includes the:
-
-    - likelihood (bilby.core.likelihood.Likelihood)
-    - priors (bilby.core.prior.PriorDict)
-    - search_parameter_keys (list)
-    - use_ratio (bool)
-    """
-
-    likelihood = attr.ib(default=None)
-    priors = attr.ib(default=None)
-    search_parameter_keys = attr.ib(default=None)
-    use_ratio = attr.ib(default=False)
-    parameters = attr.ib(default=None)
-
-
-_sampling_convenience_dump = _SamplingContainer()
-
-
-def _initialize_global_variables(
-    likelihood,
-    priors,
-    search_parameter_keys,
-    use_ratio,
-    parameters,
-):
-    """
-    Store a global copy of the likelihood, priors, and search keys for
-    multiprocessing.
-    """
-    _sampling_convenience_dump.likelihood = likelihood
-    _sampling_convenience_dump.priors = priors
-    _sampling_convenience_dump.search_parameter_keys = search_parameter_keys
-    _sampling_convenience_dump.use_ratio = use_ratio
-    _sampling_convenience_dump.parameters = deepcopy(parameters)
 
 
 def signal_wrapper(method):
@@ -232,6 +192,7 @@ class Sampler(object):
         soft_init=False,
         exit_code=130,
         npool=1,
+        pool=None,
         **kwargs,
     ):
         self.likelihood = likelihood
@@ -245,6 +206,7 @@ class Sampler(object):
         self.injection_parameters = injection_parameters
         self.meta_data = meta_data
         self.use_ratio = use_ratio
+        self.pool = pool
         self._npool = npool
         if not skip_import_verification:
             self._verify_external_sampler()
@@ -768,41 +730,44 @@ class Sampler(object):
             raise SystemExit(self.exit_code) from cause
 
     def _close_pool(self):
-        if getattr(self, "pool", None) is not None:
+        if getattr(self, "pool", None) is not None and not getattr(
+            self, "_user_pool", True
+        ):
             logger.info("Starting to close worker pool.")
-            self.pool.close()
-            self.pool.join()
+            close_pool(self.pool)
             self.pool = None
             self.kwargs["pool"] = self.pool
             logger.info("Finished closing worker pool.")
 
     def _setup_pool(self):
-        if self.kwargs.get("pool", None) is not None:
-            logger.info("Using user defined pool.")
-            self.pool = self.kwargs["pool"]
-        elif self.npool is not None and self.npool > 1:
-            logger.info(f"Setting up multiproccesing pool with {self.npool} processes")
-            import multiprocessing
+        parameters = self.priors.sample()
 
-            self.pool = multiprocessing.Pool(
-                processes=self.npool,
-                initializer=_initialize_global_variables,
-                initargs=(
-                    self.likelihood,
-                    self.priors,
-                    self._search_parameter_keys,
-                    self.use_ratio,
-                    deepcopy(self.parameters),
-                ),
-            )
+        if hasattr(self.pool, "map"):
+            self._user_pool = True
+        elif self.npool in (1, None):
+            self._user_pool = False
         else:
-            self.pool = None
-        _initialize_global_variables(
+            self._user_pool = False
+            self.pool = create_pool(
+                likelihood=self.likelihood,
+                priors=self.priors,
+                search_parameter_keys=self._search_parameter_keys,
+                use_ratio=self.use_ratio,
+                npool=self.npool,
+                pool=self.pool,
+                parameters=parameters,
+            )
+            if self.pool is not None:
+                logger.warning(
+                    "Setting up parallel pool in sampler is deprecated. Use "
+                    "bilby.utils.parallel.bilby_pool context instead."
+                )
+        initialize_global_variables(
             likelihood=self.likelihood,
             priors=self.priors,
             search_parameter_keys=self._search_parameter_keys,
             use_ratio=self.use_ratio,
-            parameters=deepcopy(self.parameters),
+            parameters=parameters,
         )
         self.kwargs["pool"] = self.pool
 
@@ -1127,8 +1092,8 @@ class LikePriorEvaluator:
         self.periodic_set = False
 
     def _setup_periodic(self):
-        priors = _sampling_convenience_dump.priors
-        search_parameter_keys = _sampling_convenience_dump.search_parameter_keys
+        priors = sampling_convenience_dump.priors
+        search_parameter_keys = sampling_convenience_dump.search_parameter_keys
         self._periodic = [
             priors[key].boundary == "periodic" for key in search_parameter_keys
         ]
@@ -1153,21 +1118,21 @@ class LikePriorEvaluator:
         return array
 
     def logl(self, v_array):
-        priors = _sampling_convenience_dump.priors
-        likelihood = _sampling_convenience_dump.likelihood
-        search_parameter_keys = _sampling_convenience_dump.search_parameter_keys
-        parameters = _sampling_convenience_dump.parameters.copy()
+        priors = sampling_convenience_dump.priors
+        likelihood = sampling_convenience_dump.likelihood
+        search_parameter_keys = sampling_convenience_dump.search_parameter_keys
+        parameters = sampling_convenience_dump.parameters.copy()
         parameters.update({key: v for key, v in zip(search_parameter_keys, v_array)})
         if priors.evaluate_constraints(parameters) == 0:
             return np.nan_to_num(-np.inf)
-        elif _sampling_convenience_dump.use_ratio:
+        elif sampling_convenience_dump.use_ratio:
             return likelihood.log_likelihood_ratio(parameters)
         else:
             return likelihood.log_likelihood(parameters)
 
     def logp(self, v_array):
-        priors = _sampling_convenience_dump.priors
-        search_parameter_keys = _sampling_convenience_dump.search_parameter_keys
+        priors = sampling_convenience_dump.priors
+        search_parameter_keys = sampling_convenience_dump.search_parameter_keys
         params = {key: t for key, t in zip(search_parameter_keys, v_array)}
         return priors.ln_prob(params)
 

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -16,48 +16,31 @@ from ..utils import (
     logger,
     safe_file_dump,
 )
+from ..utils.parallel import sampling_convenience_dump
 from ..utils.plotting import _close_new_figures
 from . import dynesty_utils
-from .base_sampler import (
-    NestedSampler,
-    ResumeError,
-    Sampler,
-    _SamplingContainer,
-    signal_wrapper,
-)
-
-
-def _set_sampling_kwargs(args):
-    nact, maxmcmc, proposals, naccept = args
-    _SamplingContainer.nact = nact
-    _SamplingContainer.maxmcmc = maxmcmc
-    _SamplingContainer.proposals = proposals
-    _SamplingContainer.naccept = naccept
+from .base_sampler import NestedSampler, ResumeError, Sampler, signal_wrapper
 
 
 def _prior_transform_wrapper(theta):
     """Wrapper to the prior transformation. Needed for multiprocessing."""
-    from .base_sampler import _sampling_convenience_dump
-
-    return _sampling_convenience_dump.priors.rescale(
-        _sampling_convenience_dump.search_parameter_keys, theta
+    return sampling_convenience_dump.priors.rescale(
+        sampling_convenience_dump.search_parameter_keys, theta
     )
 
 
 def _log_likelihood_wrapper(theta):
     """Wrapper to the log likelihood. Needed for multiprocessing."""
-    from .base_sampler import _sampling_convenience_dump
-
-    keys = _sampling_convenience_dump.search_parameter_keys
+    keys = sampling_convenience_dump.search_parameter_keys
     sampling_params = {key: t for key, t in zip(keys, theta)}
-    params = deepcopy(_sampling_convenience_dump.parameters)
+    params = deepcopy(sampling_convenience_dump.parameters)
     params.update(sampling_params)
-    if not _sampling_convenience_dump.priors.evaluate_constraints(sampling_params):
+    if not sampling_convenience_dump.priors.evaluate_constraints(sampling_params):
         return np.nan_to_num(-np.inf)
-    elif _sampling_convenience_dump.use_ratio:
-        return _sampling_convenience_dump.likelihood.log_likelihood_ratio(params)
+    elif sampling_convenience_dump.use_ratio:
+        return sampling_convenience_dump.likelihood.log_likelihood_ratio(params)
     else:
-        return _sampling_convenience_dump.likelihood.log_likelihood(params)
+        return sampling_convenience_dump.likelihood.log_likelihood(params)
 
 
 class Dynesty(NestedSampler):

--- a/bilby/core/sampler/dynesty_utils.py
+++ b/bilby/core/sampler/dynesty_utils.py
@@ -712,7 +712,7 @@ def _get_proposal_kwargs(args):
 
     The steps involved are:
 
-    - extract the requested proposal types from the :code:`_SamplingContainer`.
+    - extract the requested proposal types from the kwargs passed through from dynesty.
       If none are specified, only differential evolution will be used.
     - differential evolution requires the live points to be passed. If they are
       not present, raise an error.

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -4,8 +4,19 @@ from contextlib import contextmanager
 from .log import logger
 
 
-def create_pool(likelihood, priors, use_ratio=None, search_parameter_keys=None, npool=None, pool=None):
+def create_pool(
+    likelihood,
+    priors,
+    use_ratio=None,
+    search_parameter_keys=None,
+    npool=None,
+    pool=None,
+    parameters=None,
+):
     from ...core.sampler.base_sampler import _initialize_global_variables
+
+    if parameters is None:
+        parameters = dict()
 
     _pool = None
     if pool == "mpi":
@@ -19,6 +30,7 @@ def create_pool(likelihood, priors, use_ratio=None, search_parameter_keys=None, 
             priors=priors,
             search_parameter_keys=search_parameter_keys,
             use_ratio=use_ratio,
+            parameters=parameters,
         )
         _pool = MPIPool(use_dill=True)
         if _pool.is_master():
@@ -29,7 +41,7 @@ def create_pool(likelihood, priors, use_ratio=None, search_parameter_keys=None, 
         _pool = multiprocessing.Pool(
             processes=npool,
             initializer=_initialize_global_variables,
-            initargs=(likelihood, priors, search_parameter_keys, use_ratio),
+            initargs=(likelihood, priors, search_parameter_keys, use_ratio, parameters),
         )
         logger.info(f"Created multiprocessing pool with size {npool}")
     else:
@@ -51,6 +63,7 @@ def bilby_pool(
     search_parameter_keys=None,
     npool=None,
     pool=None,
+    parameters=None,
 ):
     if hasattr(pool, "map"):
         user_pool = True
@@ -65,6 +78,7 @@ def bilby_pool(
             use_ratio=use_ratio,
             npool=npool,
             pool=pool,
+            parameters=parameters,
         )
         yield _pool
     finally:

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -43,7 +43,7 @@ def create_pool(
     pool: schwimmbad.MPIPool, multiprocessing.Pool, None
         Returns either a pool that can be used for mapping function calls.
         Each process attached to the pool has been initialized with
-        the bilby.core.sampler._SamplingContainer.
+        the :code:`bilby.core.sampler.base_sampler._sampling_convenience_dump`.
 
     Examples
     ========
@@ -158,7 +158,7 @@ def bilby_pool(
     pool: schwimmbad.MPIPool, multiprocessing.Pool, None
         Returns either a pool that can be used for mapping function calls.
         Each process attached to the pool has been initialized with
-        the bilby.core.sampler._SamplingContainer.
+        the :code:`bilby.core.sampler.base_sampler._sampling_convenience_dump`.
 
     Examples
     ========

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -4,8 +4,8 @@ from .log import logger
 
 
 def create_pool(
-    likelihood,
-    priors,
+    likelihood=None,
+    priors=None,
     use_ratio=None,
     search_parameter_keys=None,
     npool=None,

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -36,7 +36,7 @@ def create_pool(
             logger.info(f"Created MPI pool with size {_pool.size}")
     elif pool is not None:
         _pool = pool
-    elif npool is not None:
+    elif npool not in (None, 1):
         import multiprocessing
 
         _pool = multiprocessing.Pool(

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -1,4 +1,3 @@
-import multiprocessing
 from contextlib import contextmanager
 
 from .log import logger
@@ -38,6 +37,8 @@ def create_pool(
     elif pool is not None:
         _pool = pool
     elif npool is not None:
+        import multiprocessing
+
         _pool = multiprocessing.Pool(
             processes=npool,
             initializer=_initialize_global_variables,

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -12,6 +12,61 @@ def create_pool(
     pool=None,
     parameters=None,
 ):
+    """
+    Create a parallel pool object that is initialized with variables typically
+    needed by Bilby for parallel tasks.
+
+    Parameters
+    ==========
+    likelihood: bilby.core.likelihood.Likelihood, None
+        The likelihood to copy into each process
+    priors: bilby.core.prior.PriorDict, None
+        The Bilby prior dictionary to copy into each process
+    use_ratio: bool, None
+        Whether to evaluate the log_likelihood_ratio
+    search_parameter_keys: list[str], None
+        The names fo parameters being sampled over
+    npool: int, None
+        The number of processes to use for multiprocessing.
+        If a user pool is not provided and this is either :code:`1` or :code:`None`,
+        this functions returns :code:`None`.
+    pool: pool-like, str, None
+        Either a premade pool object, or the pool kind (:code:`mpi`, :code:`multiprocessing`).
+        If a pre-made pool is passed, it is returned directly with no checks
+        performed.
+    parameters: dict, None
+        Parameters to pass through to the new processes, e.g., if default
+        parameters are to be passed.
+
+    Returns
+    =======
+    pool: schwimmbad.MPIPool, multiprocessing.Pool, None
+        Returns either a pool that can be used for mapping function calls.
+        Each process attached to the pool has been initialized with
+        the bilby.core.sampler._SamplingContainer.
+
+    Examples
+    ========
+
+    >>> import numpy as np
+    >>> from bilby.core.likelihood import AnalyticalMultidimensionalCovariantGaussian
+    >>> from bilby.core.prior import Normal, PriorDict
+    >>> from bilby.core.utils.parallel import close_pool, create_pool
+    >>> from bilby.core.sampler.base_sampler import _sampling_convenience_dump
+
+    >>> def parallel_likelihood_eval(parameters):
+    >>>     likelihood = _sampling_convenience_dump.likelihood
+    >>>     return likelihood.log_likelihood(parameters)
+
+    >>> likelihood = AnalyticalMultidimensionalCovariantGaussian(
+    >>>     mean=np.zeros(4), cov=np.eye(4)
+    >>> )
+    >>> priors = PriorDict({f"x{i}": Normal(0, 1) for ii in range(4)})
+    >>> parameters = [priors.sample() for _ in range(10)]
+    >>> pool = create_pool(likelihood, priors, npool=4)
+    >>> log_ls = list(pool.map(some_parallel_function, parameters))
+    >>> close_pool(pool)
+    """
     from ...core.sampler.base_sampler import _initialize_global_variables
 
     if parameters is None:
@@ -51,6 +106,11 @@ def create_pool(
 
 
 def close_pool(pool):
+    """
+    Safely close a parallel pool.
+    If the pool has a :code:`close` method :code:`pool.close` will be called.
+    Then, if the pool has a :code:`join` method :code:`pool.join` will be called.
+    """
     if hasattr(pool, "close"):
         pool.close()
     if hasattr(pool, "join"):
@@ -66,6 +126,62 @@ def bilby_pool(
     pool=None,
     parameters=None,
 ):
+    """
+    Yield a parallel pool object that is initialized with variables typically
+    needed by Bilby for parallel tasks that is automatically close when closing
+    the context.
+
+    Parameters
+    ==========
+    likelihood: bilby.core.likelihood.Likelihood, None
+        The likelihood to copy into each process
+    priors: bilby.core.prior.PriorDict, None
+        The Bilby prior dictionary to copy into each process
+    use_ratio: bool, None
+        Whether to evaluate the log_likelihood_ratio
+    search_parameter_keys: list[str], None
+        The names fo parameters being sampled over
+    npool: int, None
+        The number of processes to use for multiprocessing.
+        If a user pool is not provided and this is either :code:`1` or :code:`None`,
+        this functions returns :code:`None`.
+    pool: pool-like, str, None
+        Either a premade pool object, or the pool kind (:code:`mpi`, :code:`multiprocessing`).
+        If a pre-made pool is passed, it is returned directly with no checks
+        performed.
+    parameters: dict, None
+        Parameters to pass through to the new processes, e.g., if default
+        parameters are to be passed.
+
+    Yields
+    ======
+    pool: schwimmbad.MPIPool, multiprocessing.Pool, None
+        Returns either a pool that can be used for mapping function calls.
+        Each process attached to the pool has been initialized with
+        the bilby.core.sampler._SamplingContainer.
+
+    Examples
+    ========
+
+    >>> import numpy as np
+    >>> from bilby.core.likelihood import AnalyticalMultidimensionalCovariantGaussian
+    >>> from bilby.core.prior import Normal, PriorDict
+    >>> from bilby.core.utils.parallel import bilby_pool
+    >>> from bilby.core.sampler.base_sampler import _sampling_convenience_dump
+
+    >>> def parallel_likelihood_eval(parameters):
+    >>>     likelihood = _sampling_convenience_dump.likelihood
+    >>>     return likelihood.log_likelihood(parameters)
+
+    >>> likelihood = AnalyticalMultidimensionalCovariantGaussian(
+    >>>     mean=np.zeros(4), cov=np.eye(4)
+    >>> )
+    >>> priors = PriorDict({f"x{i}": Normal(0, 1) for ii in range(4)})
+    >>> parameters = [priors.sample() for _ in range(10)]
+    >>> with bilby_pool(likelihood, priors, npool=4) as pool:
+    >>>     log_ls = list(pool.map(some_parallel_function, parameters))
+
+    """
     if hasattr(pool, "map"):
         user_pool = True
     else:

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -52,8 +52,6 @@ def create_pool(
 def close_pool(pool):
     if hasattr(pool, "close"):
         pool.close()
-    else:
-        import IPython; IPython.embed()
     if hasattr(pool, "join"):
         pool.join()
 

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -1,0 +1,72 @@
+import multiprocessing
+from contextlib import contextmanager
+
+from .log import logger
+
+
+def create_pool(likelihood, priors, use_ratio=None, search_parameter_keys=None, npool=None, pool=None):
+    from ...core.sampler.base_sampler import _initialize_global_variables
+
+    _pool = None
+    if pool == "mpi":
+        try:
+            from schwimmbad import MPIPool
+        except ImportError:
+            raise ImportError("schwimmbad must be installed to use MPI pool")
+
+        _initialize_global_variables(
+            likelihood=likelihood,
+            priors=priors,
+            search_parameter_keys=search_parameter_keys,
+            use_ratio=use_ratio,
+        )
+        _pool = MPIPool(use_dill=True)
+        if _pool.is_master():
+            logger.info(f"Created MPI pool with size {_pool.size}")
+    elif pool is not None:
+        _pool = pool
+    elif npool is not None:
+        _pool = multiprocessing.Pool(
+            processes=npool,
+            initializer=_initialize_global_variables,
+            initargs=(likelihood, priors, search_parameter_keys, use_ratio),
+        )
+        logger.info(f"Created multiprocessing pool with size {npool}")
+    else:
+        _pool = None
+    return _pool
+
+
+def close_pool(pool):
+    if hasattr(pool, "close"):
+        pool.close()
+    if hasattr(pool, "join"):
+        pool.join()
+
+
+@contextmanager
+def bilby_pool(
+    likelihood, priors,
+    use_ratio=None,
+    search_parameter_keys=None,
+    npool=None,
+    pool=None,
+):
+    if hasattr(pool, "map"):
+        user_pool = True
+    else:
+        user_pool = False
+
+    try:
+        _pool = create_pool(
+            likelihood=likelihood,
+            priors=priors,
+            search_parameter_keys=search_parameter_keys,
+            use_ratio=use_ratio,
+            npool=npool,
+            pool=pool,
+        )
+        yield _pool
+    finally:
+        if not user_pool:
+            close_pool(_pool)

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -52,6 +52,8 @@ def create_pool(
 def close_pool(pool):
     if hasattr(pool, "close"):
         pool.close()
+    else:
+        import IPython; IPython.embed()
     if hasattr(pool, "join"):
         pool.join()
 
@@ -82,5 +84,5 @@ def bilby_pool(
         )
         yield _pool
     finally:
-        if not user_pool:
+        if not user_pool and "_pool" in locals():
             close_pool(_pool)

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -25,7 +25,7 @@ def create_pool(
     use_ratio: bool, None
         Whether to evaluate the log_likelihood_ratio
     search_parameter_keys: list[str], None
-        The names fo parameters being sampled over
+        The names for parameters being sampled over
     npool: int, None
         The number of processes to use for multiprocessing.
         If a user pool is not provided and this is either :code:`1` or :code:`None`,
@@ -141,7 +141,7 @@ def bilby_pool(
     use_ratio: bool, None
         Whether to evaluate the log_likelihood_ratio
     search_parameter_keys: list[str], None
-        The names fo parameters being sampled over
+        The names for parameters being sampled over
     npool: int, None
         The number of processes to use for multiprocessing.
         If a user pool is not provided and this is either :code:`1` or :code:`None`,

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -119,7 +119,8 @@ def close_pool(pool):
 
 @contextmanager
 def bilby_pool(
-    likelihood, priors,
+    likelihood=None,
+    priors=None,
     use_ratio=None,
     search_parameter_keys=None,
     npool=None,

--- a/bilby/core/utils/parallel.py
+++ b/bilby/core/utils/parallel.py
@@ -1,0 +1,287 @@
+from contextlib import contextmanager
+from copy import deepcopy
+
+import attr
+
+from .log import logger
+
+
+@attr.s
+class _SamplingContainer:
+    """
+    A container class for objects that are stored independently in each thread
+    for some samplers.
+
+    A single instance of this will appear in this module that can be access
+    by the individual samplers.
+
+    This includes the:
+
+    - likelihood (bilby.core.likelihood.Likelihood)
+    - priors (bilby.core.prior.PriorDict)
+    - search_parameter_keys (list)
+    - use_ratio (bool)
+    """
+
+    likelihood = attr.ib(default=None)
+    priors = attr.ib(default=None)
+    search_parameter_keys = attr.ib(default=None)
+    use_ratio = attr.ib(default=False)
+    parameters = attr.ib(default=None)
+
+
+sampling_convenience_dump = _SamplingContainer()
+
+
+def initialize_global_variables(
+    likelihood,
+    priors,
+    search_parameter_keys,
+    use_ratio,
+    parameters,
+):
+    """
+    Store a global copy of the likelihood, priors, and search keys for
+    multiprocessing.
+
+    Parameters
+    ==========
+    likelihood: bilby.core.likelihood.Likelihood
+        The likelihood to copy into each process
+    priors: bilby.core.prior.PriorDict
+        The Bilby prior dictionary to copy into each process
+    search_parameter_keys: list[str], None
+        The names for parameters being sampled over
+    use_ratio: bool
+        Whether to evaluate the log_likelihood_ratio
+    parameters: dict
+        A set of default parameters to pass through to the new processes,
+        e.g., if there are fixed parameters that the sampler used doesn't use.
+    """
+    sampling_convenience_dump.likelihood = likelihood
+    sampling_convenience_dump.priors = priors
+    sampling_convenience_dump.search_parameter_keys = search_parameter_keys
+    sampling_convenience_dump.use_ratio = use_ratio
+    sampling_convenience_dump.parameters = deepcopy(parameters)
+
+
+def create_pool(
+    likelihood=None,
+    priors=None,
+    use_ratio=None,
+    search_parameter_keys=None,
+    npool=None,
+    pool=None,
+    parameters=None,
+):
+    """
+    Create a parallel pool object that is initialized with variables typically
+    needed by Bilby for parallel tasks.
+
+    Parameters
+    ==========
+    likelihood: bilby.core.likelihood.Likelihood, None
+        The likelihood to copy into each process
+    priors: bilby.core.prior.PriorDict, None
+        The Bilby prior dictionary to copy into each process
+    use_ratio: bool, None
+        Whether to evaluate the log_likelihood_ratio
+    search_parameter_keys: list[str], None
+        The names for parameters being sampled over
+    npool: int, None
+        The number of processes to use for multiprocessing.
+        If a user pool is not provided and this is either :code:`1` or :code:`None`,
+        this functions returns :code:`None`.
+    pool: pool-like, str, None
+        Either a premade pool object, or the pool kind (:code:`mpi`, :code:`multiprocessing`).
+        If a pre-made pool is passed, it is returned directly with no checks
+        performed.
+    parameters: dict, None
+        Parameters to pass through to the new processes, e.g., if default
+        parameters are to be passed.
+
+    Returns
+    =======
+    pool: schwimmbad.MPIPool, multiprocessing.Pool, None
+        Returns either a pool that can be used for mapping function calls.
+        Each process attached to the pool has been initialized with
+        the :code:`bilby.core.utils.parallel.sampling_convenience_dump`.
+
+    Examples
+    ========
+
+    >>> import numpy as np
+    >>> from bilby.core.likelihood import AnalyticalMultidimensionalCovariantGaussian
+    >>> from bilby.core.prior import Normal, PriorDict
+    >>> from bilby.core.utils.parallel import close_pool, create_pool
+
+    >>> likelihood = AnalyticalMultidimensionalCovariantGaussian(
+    ...     mean=np.zeros(4), cov=np.eye(4)
+    ... )
+    >>> priors = PriorDict({f"x{ii}": Normal(0, 1) for ii in range(4)})
+    >>> parameters = [priors.sample() for _ in range(10)]
+    >>> pool = create_pool(likelihood, priors, npool=4)
+    >>> log_ls = list(pool.map(likelihood.log_likelihood, parameters))
+    >>> close_pool(pool)
+
+    .. note::
+
+        The above example passes the ``likelihood.log_likelihood`` method directly to the pool.
+        This is possible, but will lead to the likelihood object being pickled and sent to each
+        process for every call to the pool. This can add significant overhead if the likelihood
+        carries a lot of data, e.g., for the gravitational-wave transient likelihoods.
+        In this case, we recommend creating a wrapper function that uses the
+        ``sampling_convenience_dump`` to access the likelihood object, e.g.,
+
+        .. code-block:: python
+
+            >>> from bilby.core.utils.parallel import sampling_convenience_dump
+
+            >>> def parallel_likelihood_eval(parameters):
+            ...     return sampling_convenience_dump.likelihood.log_likelihood(parameters)
+    """
+    from ...core.sampler.base_sampler import initialize_global_variables
+
+    if parameters is None:
+        parameters = dict()
+
+    _pool = None
+    if pool == "mpi":
+        try:
+            from schwimmbad import MPIPool
+        except ImportError:
+            raise ImportError("schwimmbad must be installed to use MPI pool")
+
+        initialize_global_variables(
+            likelihood=likelihood,
+            priors=priors,
+            search_parameter_keys=search_parameter_keys,
+            use_ratio=use_ratio,
+            parameters=parameters,
+        )
+        _pool = MPIPool(use_dill=True)
+        if _pool.is_master():
+            logger.info(f"Created MPI pool with size {_pool.size}")
+    elif pool is not None:
+        _pool = pool
+    elif npool not in (None, 1):
+        import multiprocessing
+
+        _pool = multiprocessing.Pool(
+            processes=npool,
+            initializer=initialize_global_variables,
+            initargs=(likelihood, priors, search_parameter_keys, use_ratio, parameters),
+        )
+        logger.info(f"Created multiprocessing pool with size {npool}")
+    else:
+        _pool = None
+    return _pool
+
+
+def close_pool(pool):
+    """
+    Safely close a parallel pool.
+    If the pool has a :code:`close` method :code:`pool.close` will be called.
+    Then, if the pool has a :code:`join` method :code:`pool.join` will be called.
+    """
+    if hasattr(pool, "close"):
+        pool.close()
+    if hasattr(pool, "join"):
+        pool.join()
+
+
+@contextmanager
+def bilby_pool(
+    likelihood=None,
+    priors=None,
+    use_ratio=None,
+    search_parameter_keys=None,
+    npool=None,
+    pool=None,
+    parameters=None,
+):
+    """
+    Yield a parallel pool object that is initialized with variables typically
+    needed by Bilby for parallel tasks that is automatically close when closing
+    the context.
+
+    Parameters
+    ==========
+    likelihood: bilby.core.likelihood.Likelihood, None
+        The likelihood to copy into each process
+    priors: bilby.core.prior.PriorDict, None
+        The Bilby prior dictionary to copy into each process
+    use_ratio: bool, None
+        Whether to evaluate the log_likelihood_ratio
+    search_parameter_keys: list[str], None
+        The names for parameters being sampled over
+    npool: int, None
+        The number of processes to use for multiprocessing.
+        If a user pool is not provided and this is either :code:`1` or :code:`None`,
+        this functions returns :code:`None`.
+    pool: pool-like, str, None
+        Either a premade pool object, or the pool kind (:code:`mpi`, :code:`multiprocessing`).
+        If a pre-made pool is passed, it is returned directly with no checks
+        performed.
+    parameters: dict, None
+        Parameters to pass through to the new processes, e.g., if default
+        parameters are to be passed.
+
+    Yields
+    ======
+    pool: schwimmbad.MPIPool, multiprocessing.Pool, None
+        Returns either a pool that can be used for mapping function calls.
+        Each process attached to the pool has been initialized with
+        the :code:`bilby.core.utils.parallel.sampling_convenience_dump`.
+
+    Examples
+    ========
+
+    >>> import numpy as np
+    >>> from bilby.core.likelihood import AnalyticalMultidimensionalCovariantGaussian
+    >>> from bilby.core.prior import Normal, PriorDict
+    >>> from bilby.core.utils.parallel import bilby_pool
+
+    >>> likelihood = AnalyticalMultidimensionalCovariantGaussian(
+    ...     mean=np.zeros(4), cov=np.eye(4)
+    ... )
+    >>> priors = PriorDict({f"x{ii}": Normal(0, 1) for ii in range(4)})
+    >>> parameters = [priors.sample() for _ in range(10)]
+    >>> with bilby_pool(likelihood, priors, npool=4) as pool:
+    ...     log_ls = list(pool.map(likelihood.log_likelihood, parameters))
+
+    .. note::
+
+        The above example passes the ``likelihood.log_likelihood`` method directly to the pool.
+        This is possible, but will lead to the likelihood object being pickled and sent to each
+        process for every call to the pool. This can add significant overhead if the likelihood
+        carries a lot of data, e.g., for the gravitational-wave transient likelihoods.
+        In this case, we recommend creating a wrapper function that uses the
+        ``sampling_convenience_dump`` to access the likelihood object, e.g.,
+
+        .. code-block:: python
+
+            >>> from bilby.core.utils.parallel import sampling_convenience_dump
+
+            >>> def parallel_likelihood_eval(parameters):
+            ...     return sampling_convenience_dump.likelihood.log_likelihood(parameters)
+    """
+    if hasattr(pool, "map"):
+        user_pool = True
+    else:
+        user_pool = False
+
+    try:
+        _pool = create_pool(
+            likelihood=likelihood,
+            priors=priors,
+            search_parameter_keys=search_parameter_keys,
+            use_ratio=use_ratio,
+            npool=npool,
+            pool=pool,
+            parameters=parameters,
+        )
+        yield _pool
+    finally:
+        if not user_pool and "_pool" in locals():
+            close_pool(_pool)

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -5,7 +5,6 @@ gravitational-wave sources.
 
 import os
 import sys
-import multiprocessing
 import pickle
 
 import numpy as np
@@ -28,6 +27,7 @@ from .utils import (lalsim_SimNeutronStarEOS4ParamSDGammaCheck,
 
 from ..core.likelihood import MarginalizedLikelihoodReconstructionError
 from ..core.utils import logger, solar_mass, gravitational_constant, speed_of_light, command_line_args, safe_file_dump
+from ..core.utils.parallel import bilby_pool
 from ..core.prior import DeltaFunction
 from .utils import lalsim_SimInspiralTransformPrecessingNewInitialConditions
 from .eos.eos import IntegrateTOV
@@ -1630,7 +1630,7 @@ def binary_love_lambda_symmetric_to_lambda_1_lambda_2_automatic_marginalisation(
 
 
 def _generate_all_cbc_parameters(sample, defaults, base_conversion,
-                                 likelihood=None, priors=None, npool=1):
+                                 likelihood=None, priors=None, npool=1, pool=None):
     """Generate all cbc parameters, helper function for BBH/BNS"""
     output_sample = sample.copy()
 
@@ -1648,13 +1648,13 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
     output_sample, _ = base_conversion(output_sample)
     if likelihood is not None:
         compute_per_detector_log_likelihoods(
-            samples=output_sample, likelihood=likelihood, npool=npool)
+            samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
 
         marginalized_parameters = getattr(likelihood, "_marginalized_parameters", list())
         if len(marginalized_parameters) > 0:
             try:
                 generate_posterior_samples_from_marginalized_likelihood(
-                    samples=output_sample, likelihood=likelihood, npool=npool)
+                    samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
             except MarginalizedLikelihoodReconstructionError as e:
                 logger.warning(
                     "Marginalised parameter reconstruction failed with message "
@@ -1688,7 +1688,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
                     "Failed to generate sky frame parameters for type {}"
                     .format(type(output_sample))
                 )
-        compute_snrs(output_sample, likelihood, npool=npool)
+        compute_snrs(output_sample, likelihood=likelihood, npool=npool, pool=pool)
     for key, func in zip(["mass", "spin", "source frame"], [
             generate_mass_parameters, generate_spin_parameters,
             generate_source_frame_parameters]):
@@ -1702,7 +1702,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
     return output_sample
 
 
-def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1):
+def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1, pool=None):
     """
     From either a single sample or a set of samples fill in all missing
     BBH parameters, in place.
@@ -1724,11 +1724,11 @@ def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1):
     output_sample = _generate_all_cbc_parameters(
         sample, defaults=waveform_defaults,
         base_conversion=convert_to_lal_binary_black_hole_parameters,
-        likelihood=likelihood, priors=priors, npool=npool)
+        likelihood=likelihood, priors=priors, npool=npool, pool=pool)
     return output_sample
 
 
-def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1):
+def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1, pool=None):
     """
     From either a single sample or a set of samples fill in all missing
     BNS parameters, in place.
@@ -1755,7 +1755,7 @@ def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1):
     output_sample = _generate_all_cbc_parameters(
         sample, defaults=waveform_defaults,
         base_conversion=convert_to_lal_binary_neutron_star_parameters,
-        likelihood=likelihood, priors=priors, npool=npool)
+        likelihood=likelihood, priors=priors, npool=npool, pool=pool)
     try:
         output_sample = generate_tidal_parameters(output_sample)
     except KeyError as e:
@@ -2207,7 +2207,7 @@ def generate_source_frame_parameters(sample):
     return output_sample
 
 
-def compute_snrs(sample, likelihood, npool=1):
+def compute_snrs(sample, likelihood, npool=1, pool=None):
     """
     Compute the optimal and matched filter snrs of all posterior samples
     and print it out.
@@ -2234,23 +2234,13 @@ def compute_snrs(sample, likelihood, npool=1):
             logger.info('Computing SNRs for every sample.')
 
             fill_args = [(ii, row) for ii, row in sample.iterrows()]
-            if npool > 1:
-                from ..core.sampler.base_sampler import _initialize_global_variables
-                pool = multiprocessing.Pool(
-                    processes=npool,
-                    initializer=_initialize_global_variables,
-                    initargs=(likelihood, None, None, False, dict()),
-                )
-                logger.info(
-                    "Using a pool with size {} for nsamples={}".format(npool, len(sample))
-                )
-                new_samples = pool.map(_compute_snrs, tqdm(fill_args, file=sys.stdout))
-                pool.close()
-                pool.join()
-            else:
-                from ..core.sampler.base_sampler import _sampling_convenience_dump
-                _sampling_convenience_dump.likelihood = likelihood
-                new_samples = [_compute_snrs(xx) for xx in tqdm(fill_args, file=sys.stdout)]
+            with bilby_pool(likelihood=likelihood, npool=npool, pool=pool) as _pool:
+                if _pool is not None:
+                    new_samples = _pool.map(_compute_snrs, tqdm(fill_args, file=sys.stdout))
+                else:
+                    from ..core.sampler.base_sampler import _sampling_convenience_dump
+                    _sampling_convenience_dump.likelihood = likelihood
+                    new_samples = [_compute_snrs(xx) for xx in tqdm(fill_args, file=sys.stdout)]
 
             for ii, ifo in enumerate(likelihood.interferometers):
                 snr_updates = dict()
@@ -2283,7 +2273,7 @@ def _compute_snrs(args):
     return snrs
 
 
-def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10):
+def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10, pool=None):
     """
     Calculate the log likelihoods in each detector.
 
@@ -2324,48 +2314,30 @@ def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10)
         # Store samples to convert for checking
         cached_samples_dict["_samples"] = samples
 
-        # Set up the multiprocessing
-        if npool > 1:
-            from ..core.sampler.base_sampler import _initialize_global_variables
-            pool = multiprocessing.Pool(
-                processes=npool,
-                initializer=_initialize_global_variables,
-                initargs=(likelihood, None, None, False, dict()),
-            )
-            logger.info(
-                "Using a pool with size {} for nsamples={}"
-                .format(npool, len(samples))
-            )
-        else:
-            from ..core.sampler.base_sampler import _sampling_convenience_dump
-            _sampling_convenience_dump.likelihood = likelihood
-            pool = None
-
         fill_args = [(ii, row) for ii, row in samples.iterrows()]
         ii = 0
         pbar = tqdm(total=len(samples), file=sys.stdout)
-        while ii < len(samples):
-            if ii in cached_samples_dict:
+        with bilby_pool(likelihood=likelihood, npool=npool, pool=pool) as _pool:
+            while ii < len(samples):
+                if ii in cached_samples_dict:
+                    ii += block
+                    pbar.update(block)
+                    continue
+
+                if _pool is not None:
+                    subset_samples = _pool.map(_compute_per_detector_log_likelihoods,
+                                            fill_args[ii: ii + block])
+                else:
+                    from ..core.sampler.base_sampler import _sampling_convenience_dump
+                    _sampling_convenience_dump.likelihood = likelihood
+                    subset_samples = [list(_compute_per_detector_log_likelihoods(xx))
+                                    for xx in fill_args[ii: ii + block]]
+
+                cached_samples_dict[ii] = subset_samples
+
                 ii += block
-                pbar.update(block)
-                continue
-
-            if pool is not None:
-                subset_samples = pool.map(_compute_per_detector_log_likelihoods,
-                                          fill_args[ii: ii + block])
-            else:
-                subset_samples = [list(_compute_per_detector_log_likelihoods(xx))
-                                  for xx in fill_args[ii: ii + block]]
-
-            cached_samples_dict[ii] = subset_samples
-
-            ii += block
-            pbar.update(len(subset_samples))
+                pbar.update(len(subset_samples))
         pbar.close()
-
-        if pool is not None:
-            pool.close()
-            pool.join()
 
         new_samples = np.concatenate(
             [np.array(val) for key, val in cached_samples_dict.items() if key != "_samples"]
@@ -2393,7 +2365,7 @@ def _compute_per_detector_log_likelihoods(args):
 
 
 def generate_posterior_samples_from_marginalized_likelihood(
-        samples, likelihood, npool=1, block=10, use_cache=True):
+        samples, likelihood, npool=1, block=10, use_cache=True, pool=None):
     """
     Reconstruct the distance posterior from a run which used a likelihood which
     explicitly marginalised over time/distance/phase.
@@ -2467,50 +2439,30 @@ def generate_posterior_samples_from_marginalized_likelihood(
         # Store samples to convert for checking
         cached_samples_dict["_samples"] = samples
 
-    # Set up the multiprocessing
-    if npool > 1:
-        from ..core.sampler.base_sampler import _initialize_global_variables
-        pool = multiprocessing.Pool(
-            processes=npool,
-            initializer=_initialize_global_variables,
-            initargs=(likelihood, None, None, False, dict()),
-        )
-        logger.info(
-            "Using a pool with size {} for nsamples={}"
-            .format(npool, len(samples))
-        )
-    else:
-        from ..core.sampler.base_sampler import _sampling_convenience_dump
-        _sampling_convenience_dump.likelihood = likelihood
-        pool = None
-
     seeds = generate_seeds(len(samples))
     fill_args = [(ii, row, seed) for (ii, row), seed in zip(samples.iterrows(), seeds)]
     ii = 0
     pbar = tqdm(total=len(samples), file=sys.stdout)
-    while ii < len(samples):
-        if ii in cached_samples_dict:
+    with bilby_pool(likelihood=likelihood, npool=npool, pool=pool) as _pool:
+        while ii < len(samples):
+            if ii in cached_samples_dict:
+                ii += block
+                pbar.update(block)
+                continue
+
+            if _pool is not None:
+                subset_samples = _pool.map(fill_sample, fill_args[ii: ii + block])
+            else:
+                subset_samples = [list(fill_sample(xx)) for xx in fill_args[ii: ii + block]]
+
+            cached_samples_dict[ii] = subset_samples
+
+            if use_cache:
+                safe_file_dump(cached_samples_dict, cache_filename, "pickle")
+
             ii += block
-            pbar.update(block)
-            continue
-
-        if pool is not None:
-            subset_samples = pool.map(fill_sample, fill_args[ii: ii + block])
-        else:
-            subset_samples = [list(fill_sample(xx)) for xx in fill_args[ii: ii + block]]
-
-        cached_samples_dict[ii] = subset_samples
-
-        if use_cache:
-            safe_file_dump(cached_samples_dict, cache_filename, "pickle")
-
-        ii += block
-        pbar.update(len(subset_samples))
+            pbar.update(len(subset_samples))
     pbar.close()
-
-    if pool is not None:
-        pool.close()
-        pool.join()
 
     new_samples = np.concatenate(
         [np.array(val) for key, val in cached_samples_dict.items() if key != "_samples"]
@@ -2560,7 +2512,7 @@ def identity_map_conversion(parameters):
     return parameters, []
 
 
-def identity_map_generation(sample, likelihood=None, priors=None, npool=1):
+def identity_map_generation(sample, likelihood=None, priors=None, npool=1, pool=None):
     """An identity map generation function that handles marginalizations, SNRs, etc. correctly,
     but does not attempt e.g. conversions in mass or spins
 
@@ -2585,13 +2537,13 @@ def identity_map_generation(sample, likelihood=None, priors=None, npool=1):
 
     if likelihood is not None:
         compute_per_detector_log_likelihoods(
-            samples=output_sample, likelihood=likelihood, npool=npool)
+            samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
 
         marginalized_parameters = getattr(likelihood, "_marginalized_parameters", list())
         if len(marginalized_parameters) > 0:
             try:
                 generate_posterior_samples_from_marginalized_likelihood(
-                    samples=output_sample, likelihood=likelihood, npool=npool)
+                    samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
             except MarginalizedLikelihoodReconstructionError as e:
                 logger.warning(
                     "Marginalised parameter reconstruction failed with message "
@@ -2600,7 +2552,7 @@ def identity_map_generation(sample, likelihood=None, priors=None, npool=1):
                 )
 
         if ("ra" in output_sample.keys() and "dec" in output_sample.keys() and "psi" in output_sample.keys()):
-            compute_snrs(output_sample, likelihood, npool=npool)
+            compute_snrs(output_sample, likelihood, npool=npool, pool=pool)
         else:
             logger.info(
                 "Skipping SNR computation since samples have insufficient sky location information"

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -2325,13 +2325,17 @@ def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10,
                     continue
 
                 if _pool is not None:
-                    subset_samples = _pool.map(_compute_per_detector_log_likelihoods,
-                                            fill_args[ii: ii + block])
+                    subset_samples = _pool.map(
+                        _compute_per_detector_log_likelihoods,
+                        fill_args[ii: ii + block]
+                    )
                 else:
                     from ..core.sampler.base_sampler import _sampling_convenience_dump
                     _sampling_convenience_dump.likelihood = likelihood
-                    subset_samples = [list(_compute_per_detector_log_likelihoods(xx))
-                                    for xx in fill_args[ii: ii + block]]
+                    subset_samples = [
+                        list(_compute_per_detector_log_likelihoods(xx))
+                        for xx in fill_args[ii: ii + block]
+                    ]
 
                 cached_samples_dict[ii] = subset_samples
 

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -2234,7 +2234,7 @@ def compute_snrs(sample, likelihood, npool=1, pool=None):
             logger.info('Computing SNRs for every sample.')
 
             fill_args = [(ii, row) for ii, row in sample.iterrows()]
-            with bilby_pool(likelihood=likelihood, npool=npool, pool=pool) as _pool:
+            with bilby_pool(likelihood=likelihood, priors=None, npool=npool, pool=pool) as _pool:
                 if _pool is not None:
                     new_samples = _pool.map(_compute_snrs, tqdm(fill_args, file=sys.stdout))
                 else:
@@ -2317,7 +2317,7 @@ def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10,
         fill_args = [(ii, row) for ii, row in samples.iterrows()]
         ii = 0
         pbar = tqdm(total=len(samples), file=sys.stdout)
-        with bilby_pool(likelihood=likelihood, npool=npool, pool=pool) as _pool:
+        with bilby_pool(likelihood=likelihood, priors=None, npool=npool, pool=pool) as _pool:
             while ii < len(samples):
                 if ii in cached_samples_dict:
                     ii += block
@@ -2443,7 +2443,7 @@ def generate_posterior_samples_from_marginalized_likelihood(
     fill_args = [(ii, row, seed) for (ii, row), seed in zip(samples.iterrows(), seeds)]
     ii = 0
     pbar = tqdm(total=len(samples), file=sys.stdout)
-    with bilby_pool(likelihood=likelihood, npool=npool, pool=pool) as _pool:
+    with bilby_pool(likelihood=likelihood, priors=None, npool=npool, pool=pool) as _pool:
         while ii < len(samples):
             if ii in cached_samples_dict:
                 ii += block

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -2325,17 +2325,16 @@ def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10,
                     continue
 
                 if _pool is not None:
-                    subset_samples = _pool.map(
-                        _compute_per_detector_log_likelihoods,
-                        fill_args[ii: ii + block]
-                    )
+                    map_fn = _pool.map
                 else:
+                    map_fn = map
                     from ..core.sampler.base_sampler import _sampling_convenience_dump
                     _sampling_convenience_dump.likelihood = likelihood
-                    subset_samples = [
-                        list(_compute_per_detector_log_likelihoods(xx))
-                        for xx in fill_args[ii: ii + block]
-                    ]
+
+                subset_samples = list(map_fn(
+                    _compute_per_detector_log_likelihoods,
+                    fill_args[ii: ii + block],
+                ))
 
                 cached_samples_dict[ii] = subset_samples
 
@@ -2457,7 +2456,7 @@ def generate_posterior_samples_from_marginalized_likelihood(
             if _pool is not None:
                 subset_samples = _pool.map(fill_sample, fill_args[ii: ii + block])
             else:
-                subset_samples = [list(fill_sample(xx)) for xx in fill_args[ii: ii + block]]
+                subset_samples = list(map(fill_sample, fill_args[ii: ii + block]))
 
             cached_samples_dict[ii] = subset_samples
 

--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -5,7 +5,6 @@ gravitational-wave sources.
 
 import os
 import sys
-import multiprocessing
 import pickle
 
 import numpy as np
@@ -29,6 +28,7 @@ from .utils import (lalsim_SimNeutronStarEOS4ParamSDGammaCheck,
 from ..compat.utils import array_module
 from ..core.likelihood import MarginalizedLikelihoodReconstructionError
 from ..core.utils import logger, solar_mass, gravitational_constant, speed_of_light, command_line_args, safe_file_dump
+from ..core.utils.parallel import bilby_pool, sampling_convenience_dump
 from ..core.prior import DeltaFunction
 from .utils import lalsim_SimInspiralTransformPrecessingNewInitialConditions
 from .eos.eos import IntegrateTOV
@@ -1633,7 +1633,7 @@ def binary_love_lambda_symmetric_to_lambda_1_lambda_2_automatic_marginalisation(
 
 
 def _generate_all_cbc_parameters(sample, defaults, base_conversion,
-                                 likelihood=None, priors=None, npool=1):
+                                 likelihood=None, priors=None, npool=1, pool=None):
     """Generate all cbc parameters, helper function for BBH/BNS"""
     output_sample = sample.copy()
 
@@ -1663,13 +1663,13 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
             output_sample["time_jitter"] = 0.0
 
         compute_per_detector_log_likelihoods(
-            samples=output_sample, likelihood=likelihood, npool=npool)
+            samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
 
         marginalized_parameters = getattr(likelihood, "_marginalized_parameters", list())
         if len(marginalized_parameters) > 0:
             try:
                 generate_posterior_samples_from_marginalized_likelihood(
-                    samples=output_sample, likelihood=likelihood, npool=npool)
+                    samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
             except MarginalizedLikelihoodReconstructionError as e:
                 logger.warning(
                     "Marginalised parameter reconstruction failed with message "
@@ -1703,7 +1703,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
                     "Failed to generate sky frame parameters for type {}"
                     .format(type(output_sample))
                 )
-        compute_snrs(output_sample, likelihood, npool=npool)
+        compute_snrs(output_sample, likelihood=likelihood, npool=npool, pool=pool)
         # Remove the time jitter if it was added
         if added_time_jitter:
             output_sample.pop("time_jitter")
@@ -1720,7 +1720,7 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
     return output_sample
 
 
-def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1):
+def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1, pool=None):
     """
     From either a single sample or a set of samples fill in all missing
     BBH parameters, in place.
@@ -1742,11 +1742,11 @@ def generate_all_bbh_parameters(sample, likelihood=None, priors=None, npool=1):
     output_sample = _generate_all_cbc_parameters(
         sample, defaults=waveform_defaults,
         base_conversion=convert_to_lal_binary_black_hole_parameters,
-        likelihood=likelihood, priors=priors, npool=npool)
+        likelihood=likelihood, priors=priors, npool=npool, pool=pool)
     return output_sample
 
 
-def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1):
+def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1, pool=None):
     """
     From either a single sample or a set of samples fill in all missing
     BNS parameters, in place.
@@ -1773,7 +1773,7 @@ def generate_all_bns_parameters(sample, likelihood=None, priors=None, npool=1):
     output_sample = _generate_all_cbc_parameters(
         sample, defaults=waveform_defaults,
         base_conversion=convert_to_lal_binary_neutron_star_parameters,
-        likelihood=likelihood, priors=priors, npool=npool)
+        likelihood=likelihood, priors=priors, npool=npool, pool=pool)
     try:
         output_sample = generate_tidal_parameters(output_sample)
     except KeyError as e:
@@ -2227,7 +2227,7 @@ def generate_source_frame_parameters(sample):
     return output_sample
 
 
-def compute_snrs(sample, likelihood, npool=1):
+def compute_snrs(sample, likelihood, npool=1, pool=None):
     """
     Compute the optimal and matched filter snrs of all posterior samples
     and print it out.
@@ -2254,23 +2254,12 @@ def compute_snrs(sample, likelihood, npool=1):
             logger.info('Computing SNRs for every sample.')
 
             fill_args = [(ii, row) for ii, row in sample.iterrows()]
-            if npool > 1:
-                from ..core.sampler.base_sampler import _initialize_global_variables
-                pool = multiprocessing.Pool(
-                    processes=npool,
-                    initializer=_initialize_global_variables,
-                    initargs=(likelihood, None, None, False, dict()),
-                )
-                logger.info(
-                    "Using a pool with size {} for nsamples={}".format(npool, len(sample))
-                )
-                new_samples = pool.map(_compute_snrs, tqdm(fill_args, file=sys.stdout))
-                pool.close()
-                pool.join()
-            else:
-                from ..core.sampler.base_sampler import _sampling_convenience_dump
-                _sampling_convenience_dump.likelihood = likelihood
-                new_samples = [_compute_snrs(xx) for xx in tqdm(fill_args, file=sys.stdout)]
+            with bilby_pool(likelihood=likelihood, priors=None, npool=npool, pool=pool) as _pool:
+                if _pool is not None:
+                    new_samples = _pool.map(_compute_snrs, tqdm(fill_args, file=sys.stdout))
+                else:
+                    sampling_convenience_dump.likelihood = likelihood
+                    new_samples = [_compute_snrs(xx) for xx in tqdm(fill_args, file=sys.stdout)]
 
             for ii, ifo in enumerate(likelihood.interferometers):
                 snr_updates = dict()
@@ -2288,8 +2277,7 @@ def compute_snrs(sample, likelihood, npool=1):
 
 def _compute_snrs(args):
     """A wrapper of computing the SNRs to enable multiprocessing"""
-    from ..core.sampler.base_sampler import _sampling_convenience_dump
-    likelihood = _sampling_convenience_dump.likelihood
+    likelihood = sampling_convenience_dump.likelihood
     ii, sample = args
     sample = dict(sample).copy()
     signal_polarizations = likelihood.waveform_generator.frequency_domain_strain(
@@ -2303,7 +2291,7 @@ def _compute_snrs(args):
     return snrs
 
 
-def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10):
+def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10, pool=None):
     """
     Calculate the log likelihoods in each detector.
 
@@ -2344,48 +2332,32 @@ def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10)
         # Store samples to convert for checking
         cached_samples_dict["_samples"] = samples
 
-        # Set up the multiprocessing
-        if npool > 1:
-            from ..core.sampler.base_sampler import _initialize_global_variables
-            pool = multiprocessing.Pool(
-                processes=npool,
-                initializer=_initialize_global_variables,
-                initargs=(likelihood, None, None, False, dict()),
-            )
-            logger.info(
-                "Using a pool with size {} for nsamples={}"
-                .format(npool, len(samples))
-            )
-        else:
-            from ..core.sampler.base_sampler import _sampling_convenience_dump
-            _sampling_convenience_dump.likelihood = likelihood
-            pool = None
-
         fill_args = [(ii, row) for ii, row in samples.iterrows()]
         ii = 0
         pbar = tqdm(total=len(samples), file=sys.stdout)
-        while ii < len(samples):
-            if ii in cached_samples_dict:
+        with bilby_pool(likelihood=likelihood, priors=None, npool=npool, pool=pool) as _pool:
+            while ii < len(samples):
+                if ii in cached_samples_dict:
+                    ii += block
+                    pbar.update(block)
+                    continue
+
+                if _pool is not None:
+                    map_fn = _pool.map
+                else:
+                    map_fn = map
+                    sampling_convenience_dump.likelihood = likelihood
+
+                subset_samples = list(map_fn(
+                    _compute_per_detector_log_likelihoods,
+                    fill_args[ii: ii + block],
+                ))
+
+                cached_samples_dict[ii] = subset_samples
+
                 ii += block
-                pbar.update(block)
-                continue
-
-            if pool is not None:
-                subset_samples = pool.map(_compute_per_detector_log_likelihoods,
-                                          fill_args[ii: ii + block])
-            else:
-                subset_samples = [list(_compute_per_detector_log_likelihoods(xx))
-                                  for xx in fill_args[ii: ii + block]]
-
-            cached_samples_dict[ii] = subset_samples
-
-            ii += block
-            pbar.update(len(subset_samples))
+                pbar.update(len(subset_samples))
         pbar.close()
-
-        if pool is not None:
-            pool.close()
-            pool.join()
 
         new_samples = np.concatenate(
             [np.array(val) for key, val in cached_samples_dict.items() if key != "_samples"]
@@ -2403,8 +2375,7 @@ def compute_per_detector_log_likelihoods(samples, likelihood, npool=1, block=10)
 
 def _compute_per_detector_log_likelihoods(args):
     """A wrapper of computing the per-detector log likelihoods to enable multiprocessing"""
-    from ..core.sampler.base_sampler import _sampling_convenience_dump
-    likelihood = _sampling_convenience_dump.likelihood
+    likelihood = sampling_convenience_dump.likelihood
     _, sample = args
     sample = dict(sample).copy()
     new_sample = likelihood.compute_per_detector_log_likelihood(sample)
@@ -2413,7 +2384,7 @@ def _compute_per_detector_log_likelihoods(args):
 
 
 def generate_posterior_samples_from_marginalized_likelihood(
-        samples, likelihood, npool=1, block=10, use_cache=True):
+        samples, likelihood, npool=1, block=10, use_cache=True, pool=None):
     """
     Reconstruct the distance posterior from a run which used a likelihood which
     explicitly marginalised over time/distance/phase.
@@ -2487,50 +2458,30 @@ def generate_posterior_samples_from_marginalized_likelihood(
         # Store samples to convert for checking
         cached_samples_dict["_samples"] = samples
 
-    # Set up the multiprocessing
-    if npool > 1:
-        from ..core.sampler.base_sampler import _initialize_global_variables
-        pool = multiprocessing.Pool(
-            processes=npool,
-            initializer=_initialize_global_variables,
-            initargs=(likelihood, None, None, False, dict()),
-        )
-        logger.info(
-            "Using a pool with size {} for nsamples={}"
-            .format(npool, len(samples))
-        )
-    else:
-        from ..core.sampler.base_sampler import _sampling_convenience_dump
-        _sampling_convenience_dump.likelihood = likelihood
-        pool = None
-
     seeds = generate_seeds(len(samples))
     fill_args = [(ii, row, seed) for (ii, row), seed in zip(samples.iterrows(), seeds)]
     ii = 0
     pbar = tqdm(total=len(samples), file=sys.stdout)
-    while ii < len(samples):
-        if ii in cached_samples_dict:
+    with bilby_pool(likelihood=likelihood, priors=None, npool=npool, pool=pool) as _pool:
+        while ii < len(samples):
+            if ii in cached_samples_dict:
+                ii += block
+                pbar.update(block)
+                continue
+
+            if _pool is not None:
+                subset_samples = _pool.map(fill_sample, fill_args[ii: ii + block])
+            else:
+                subset_samples = list(map(fill_sample, fill_args[ii: ii + block]))
+
+            cached_samples_dict[ii] = subset_samples
+
+            if use_cache:
+                safe_file_dump(cached_samples_dict, cache_filename, "pickle")
+
             ii += block
-            pbar.update(block)
-            continue
-
-        if pool is not None:
-            subset_samples = pool.map(fill_sample, fill_args[ii: ii + block])
-        else:
-            subset_samples = [list(fill_sample(xx)) for xx in fill_args[ii: ii + block]]
-
-        cached_samples_dict[ii] = subset_samples
-
-        if use_cache:
-            safe_file_dump(cached_samples_dict, cache_filename, "pickle")
-
-        ii += block
-        pbar.update(len(subset_samples))
+            pbar.update(len(subset_samples))
     pbar.close()
-
-    if pool is not None:
-        pool.close()
-        pool.join()
 
     new_samples = np.concatenate(
         [np.array(val) for key, val in cached_samples_dict.items() if key != "_samples"]
@@ -2561,12 +2512,11 @@ def generate_sky_frame_parameters(samples, likelihood):
 
 
 def fill_sample(args):
-    from ..core.sampler.base_sampler import _sampling_convenience_dump
     from ..core.utils.random import seed
 
     _, sample, rseed = args
     seed(rseed)
-    likelihood = _sampling_convenience_dump.likelihood
+    likelihood = sampling_convenience_dump.likelihood
     marginalized_parameters = getattr(likelihood, "_marginalized_parameters", list())
     sample = dict(sample).copy()
     new_sample = likelihood.generate_posterior_sample_from_marginalized_likelihood(sample)
@@ -2580,7 +2530,7 @@ def identity_map_conversion(parameters):
     return parameters, []
 
 
-def identity_map_generation(sample, likelihood=None, priors=None, npool=1):
+def identity_map_generation(sample, likelihood=None, priors=None, npool=1, pool=None):
     """An identity map generation function that handles marginalizations, SNRs, etc. correctly,
     but does not attempt e.g. conversions in mass or spins
 
@@ -2605,13 +2555,13 @@ def identity_map_generation(sample, likelihood=None, priors=None, npool=1):
 
     if likelihood is not None:
         compute_per_detector_log_likelihoods(
-            samples=output_sample, likelihood=likelihood, npool=npool)
+            samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
 
         marginalized_parameters = getattr(likelihood, "_marginalized_parameters", list())
         if len(marginalized_parameters) > 0:
             try:
                 generate_posterior_samples_from_marginalized_likelihood(
-                    samples=output_sample, likelihood=likelihood, npool=npool)
+                    samples=output_sample, likelihood=likelihood, npool=npool, pool=pool)
             except MarginalizedLikelihoodReconstructionError as e:
                 logger.warning(
                     "Marginalised parameter reconstruction failed with message "
@@ -2620,7 +2570,7 @@ def identity_map_generation(sample, likelihood=None, priors=None, npool=1):
                 )
 
         if ("ra" in output_sample.keys() and "dec" in output_sample.keys() and "psi" in output_sample.keys()):
-            compute_snrs(output_sample, likelihood, npool=npool)
+            compute_snrs(output_sample, likelihood, npool=npool, pool=pool)
         else:
             logger.info(
                 "Skipping SNR computation since samples have insufficient sky location information"

--- a/docs/parallelisation.rst
+++ b/docs/parallelisation.rst
@@ -1,0 +1,140 @@
+================
+Parallelisation
+================
+
+Many of the samplers supported by Bilby can leverage parallelisation over multiple
+CPU cores. There are a range of methods that can be used to achieve this, including
+the built-in ``multiprocessing`` module to parallelize over multiple cores on a
+single machine, or using MPI to parallelize over multiple nodes on a computing cluster.
+This page specifically describes how to use parallelisation of likelihood calls across
+multiple processes, rather than parallelisation inside likelihood calls, e.g., using
+GPUs via the `Python array API <array_api.rst>`__.
+
+Parallelisation in Bilby relies on global storage of the likelihood and priors inside
+``bilby.core.utils.parallel.sampling_convenience_dump``, which must be initialized in
+each worker process. We support multiple ways of performing this initialization.
+
+.. note::
+
+    Recent versions of Python include freethreaded builds allowing efficient
+    thread-based parallelism. We do not currently support thread-based parallelism
+    due to the use of global storage of the likelihood and priors.
+    However, we plan to remove this limitation in a future release.
+
+Default parallelisation
+=======================
+
+The default approach is to set ``npool`` when calling ``run_sampler``. Bilby
+creates a :class:`multiprocessing.Pool`, initializes each worker with the
+likelihood and priors, and closes the pool when the run completes. An ``npool``
+of ``1`` (the default) or ``None`` runs without a pool.
+
+.. code-block:: python
+
+	import bilby
+
+	result = bilby.run_sampler(
+		likelihood=likelihood,
+		priors=priors,
+		sampler="dynesty",
+		npool=4,
+	)
+
+The number of workers that a sampler actually uses can depend on that
+sampler's options. Refer to the sampler-specific documentation when choosing
+the pool size.
+
+``run_sampler`` also passes its pool to the result conversion function. This
+means that a conversion function which accepts the optional ``npool`` and
+``pool`` arguments can use the same workers after sampling. For example, the
+gravitational-wave conversion functions use this to calculate quantities for
+each posterior sample in parallel.
+
+.. code-block:: python
+
+	result = bilby.run_sampler(
+		likelihood=likelihood,
+		priors=priors,
+		sampler="dynesty",
+		npool=4,
+		conversion_function=bilby.gw.conversion.generate_all_bbh_parameters,
+	)
+
+The conversion function should pass ``npool`` and ``pool`` through to any
+Bilby helper which supports parallel processing. A minimal function with the
+expected signature is:
+
+.. code-block:: python
+
+	def add_parameters(samples, likelihood=None, priors=None, npool=1, pool=None):
+		samples = samples.copy()
+		# Calculate and add derived parameters to samples here.
+		return samples
+
+Managing a pool with ``bilby_pool``
+===================================
+
+Use ``bilby_pool`` when performing parallel work outside ``run_sampler``. It
+creates and initializes a pool, yields it, and closes only pools it created.
+The context manager also accepts an existing pool without closing it.
+
+.. code-block:: python
+
+	from bilby.core.utils.parallel import bilby_pool
+
+	with bilby_pool(likelihood=likelihood, priors=priors, npool=4) as pool:
+		values = list(pool.map(evaluate_sample, samples))
+
+For ``npool=1`` or ``None``, the yielded value is ``None``. Code using the
+pool should therefore provide a serial fallback:
+
+.. code-block:: python
+
+	with bilby_pool(likelihood=likelihood, priors=priors, npool=npool) as pool:
+		map_function = pool.map if pool is not None else map
+		values = list(map_function(evaluate_sample, samples))
+
+Using a custom pool
+===================
+
+To run with a custom pool, e.g., using MPI, create a pool such as
+:class:`schwimmbad.MPIPool` and pass it to ``run_sampler``. A user-supplied pool
+remains the caller's responsibility to close. Each MPI rank must initialize
+Bilby's worker globals before worker ranks begin waiting for work.
+Run the script with an MPI launcher, for example ``mpiexec -n 4 python analysis.py``.
+
+.. code-block:: python
+
+	import sys
+
+	import bilby
+	from schwimmbad import MPIPool
+	from bilby.core.utils.parallel import initialize_global_variables
+
+	pool = MPIPool(use_dill=True)
+	initialize_global_variables(
+		likelihood=likelihood,
+		priors=priors,
+		search_parameter_keys=["mass_1", "mass_2"],
+		use_ratio=False,
+		parameters=priors.sample(),
+	)
+
+	if not pool.is_master():
+		pool.wait()
+		sys.exit(0)
+
+	try:
+		result = bilby.run_sampler(
+			likelihood=likelihood,
+			priors=priors,
+			sampler="dynesty",
+			pool=pool,
+		)
+	finally:
+		pool.close()
+
+Set ``search_parameter_keys`` to the names of the parameters sampled by the
+run, and set ``use_ratio`` to match the requested likelihood evaluation. For
+more control, the same initialization pattern applies to any pool-like object
+that supports ``map`` and is supplied through the ``pool`` argument.

--- a/pixi.lock
+++ b/pixi.lock
@@ -438,6 +438,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
@@ -451,6 +452,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -478,12 +481,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-21.0.0-h790f06f_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h4bd6b51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-hfb7daa7_5.conda
@@ -493,9 +498,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.10.0-cpu_mkl_h0bc6d91_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -516,7 +523,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -528,6 +537,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.8-h2fe1745_110.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.1-hd747db4_0.conda
@@ -561,11 +571,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.0-h6441bc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py313h29aa505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py313hafbe609_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.26-h5ac9029_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -574,6 +586,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.6.0-hb729f83_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.19.1-h567e125_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -724,6 +738,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -987,6 +1002,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -1191,6 +1207,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -1201,6 +1219,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblal-7.6.1-fftw_h2bd2a44_100.conda
@@ -1214,6 +1233,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.0-h7a62e17_0.conda
@@ -1240,7 +1260,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py313h36cb854_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py313h56deecd_1.conda
@@ -1248,6 +1270,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -1282,6 +1305,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py313hb9d2816_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -1413,6 +1437,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h982d582_5.conda
@@ -1427,6 +1452,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -1457,12 +1484,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h3133023_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_4_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h31fc519_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
@@ -1474,9 +1503,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.13.0-cpu_mkl_h40bd1c6_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -1499,7 +1530,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.66.0-py313h5d5ffb9_1.conda
@@ -1508,6 +1541,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.10-hee33aa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
@@ -1538,10 +1572,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py313h29aa505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -1550,6 +1586,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.8.0-h539fd1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.22.0-hb659a20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -1666,6 +1704,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -1846,6 +1885,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -2011,6 +2051,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -2023,6 +2065,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.3.0-h5a65909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
@@ -2037,6 +2080,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-h7a62e17_0.conda
@@ -2064,7 +2108,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.1-py313h43b7ab6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py313h56deecd_1.conda
@@ -2072,6 +2118,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -2104,6 +2151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -2222,6 +2270,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
@@ -2235,6 +2284,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -2262,12 +2313,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-21.0.0-h790f06f_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h4bd6b51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-hfb7daa7_5.conda
@@ -2277,9 +2330,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.10.0-cpu_mkl_h0bc6d91_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -2300,7 +2355,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -2312,6 +2369,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.8-h2fe1745_110.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.1-hd747db4_0.conda
@@ -2344,10 +2402,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.0-h6441bc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py313h29aa505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.26-h5ac9029_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -2356,6 +2416,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.6.0-hb729f83_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.19.1-h567e125_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -2474,6 +2536,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -2639,6 +2702,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -2799,6 +2863,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -2809,6 +2875,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblal-7.6.1-fftw_h2bd2a44_100.conda
@@ -2822,6 +2889,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-h7a62e17_0.conda
@@ -2848,7 +2916,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py313h36cb854_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py313h56deecd_1.conda
@@ -2856,6 +2926,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -2886,6 +2957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -2993,6 +3065,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h982d582_5.conda
@@ -3007,6 +3080,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -3037,12 +3112,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h3133023_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_4_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h31fc519_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
@@ -3054,9 +3131,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.13.0-cpu_mkl_h40bd1c6_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -3079,7 +3158,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.66.0-py313h5d5ffb9_1.conda
@@ -3088,6 +3169,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.10-hee33aa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
@@ -3118,10 +3200,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py313h29aa505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -3130,6 +3214,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.8.0-h539fd1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.22.0-hb659a20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -3246,6 +3332,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -3417,6 +3504,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -3582,6 +3670,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -3594,6 +3684,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.3.0-h5a65909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
@@ -3608,6 +3699,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-h7a62e17_0.conda
@@ -3635,7 +3727,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.1-py313h43b7ab6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py313h56deecd_1.conda
@@ -3643,6 +3737,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -3675,6 +3770,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -3785,6 +3881,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h982d582_5.conda
@@ -3799,6 +3896,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -3828,6 +3927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
@@ -3846,9 +3946,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.13.0-cpu_mkl_h40bd1c6_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -3871,7 +3973,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py311h6c43bbb_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-hfbb40bb_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py311h3778330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py311haee01d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.66.0-py311hc665b79_1.conda
@@ -3913,10 +4018,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py311h0372a8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py311h38be061_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py311ha15b03d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -3925,6 +4032,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.22.0-hb659a20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-hd6090a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py311h49ec1c0_0.conda
@@ -4038,6 +4146,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -4205,6 +4314,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -4373,6 +4483,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -4385,6 +4497,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.3.0-h5a65909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
@@ -4398,6 +4511,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.0-h7a62e17_0.conda
@@ -4425,7 +4539,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.1-py311h3c3ad35_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py311h61b4f52_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py311ha275503_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py311he363849_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py311h6ad6fc7_1.conda
@@ -4434,6 +4550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py311h572238d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -4468,6 +4585,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py311hc949640_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py311h267d04e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py311hf1dd2ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py311h9a58382_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -4557,6 +4675,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/htgettoken-2.6-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/igwn-segments-2.1.1-py312h53c857e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/impi_rt-2021.18.0-h4715778_753.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
@@ -4665,7 +4784,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-impi.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py312h18f78f0_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.66.0-py312h8285ef7_1.conda
@@ -4711,6 +4833,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py312h7900ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -5012,6 +5135,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -5181,6 +5305,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -5193,6 +5319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.3.0-h5a65909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
@@ -5206,6 +5333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.0-h7a62e17_0.conda
@@ -5233,7 +5361,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.1-py312h07c8dfe_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py312h50e9609_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py312hdf3e818_1.conda
@@ -5242,6 +5372,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py312h766f71e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -5276,6 +5407,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py312h81bd7bf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py312he5ca3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py312h4519d97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -5385,6 +5517,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
@@ -5398,6 +5531,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -5425,12 +5560,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-19.0.1-h790f06f_33_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h4bd6b51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-hfb7daa7_5.conda
@@ -5440,9 +5577,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.10.0-cpu_mkl_h0bc6d91_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -5463,7 +5602,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -5475,6 +5616,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.8-h2fe1745_110.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.1-hd747db4_0.conda
@@ -5507,10 +5649,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.0-h6441bc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py313h29aa505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.26-h5ac9029_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -5519,6 +5663,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.6.0-hb729f83_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.19.1-h567e125_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -5637,6 +5783,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -5802,6 +5949,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -5962,6 +6110,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -5972,6 +6122,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblal-7.6.1-fftw_h2bd2a44_100.conda
@@ -5985,6 +6136,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.0-h7a62e17_0.conda
@@ -6011,7 +6163,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py313h36cb854_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py313h56deecd_1.conda
@@ -6019,6 +6173,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -6049,6 +6204,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -6455,6 +6611,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h982d582_5.conda
@@ -6469,6 +6626,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libframel-8.48.5-ha02e5fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
@@ -6499,12 +6658,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h3133023_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_4_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h31fc519_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
@@ -6516,9 +6677,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.13.0-cpu_mkl_h40bd1c6_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
@@ -6541,7 +6704,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.66.0-py313h5d5ffb9_1.conda
@@ -6550,6 +6715,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.10-hee33aa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
@@ -6580,10 +6746,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quaternion-2024.0.13-py313h29aa505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.7.19-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -6592,6 +6760,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.8.0-h539fd1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.22.0-hb659a20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -6708,6 +6878,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -6879,6 +7050,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -7044,6 +7216,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libframel-8.48.5-h2f1a0bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -7056,6 +7230,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.3.0-h5a65909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
@@ -7070,6 +7245,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-h7a62e17_0.conda
@@ -7097,7 +7273,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.1-py313h43b7ab6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py313h56deecd_1.conda
@@ -7105,6 +7283,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onednn-3.12-omp_h95bb4b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.1-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
@@ -7137,6 +7316,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.7.19-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
@@ -9755,6 +9935,23 @@ packages:
   run_exports: {}
   size: 96117
   timestamp: 1770797825361
+- conda: https://conda.anaconda.org/conda-forge/linux-64/impi_rt-2021.18.0-h4715778_753.conda
+  sha256: 341f15648e3b747f36847e9902dbda73cbb5efb762b5db67e3c9117c1808a3ae
+  md5: 8ccefe9778877c61253aa347899b0825
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvm-openmp >=22.1.8
+  - mpi 1.0 impi
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 70407313
+  timestamp: 1786085744881
 - conda: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_0.conda
   sha256: 74d0a62d64cbe84a916ab437f71c61bf113b29a2b75e80cb5cc440626eef947e
   md5: e246309d3884a2b8a4cde89d17f4a1a3
@@ -10576,6 +10773,20 @@ packages:
     - libbrotlienc >=1.2.0,<1.3.0a0
   size: 298378
   timestamp: 1764017210931
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+  sha256: 8cb25174d6b6fac95d31e86cfe41faffc8ee9dacbf2bfd22e6c23377e8f338c1
+  md5: 5db514adf5f843126ff846d1510f22a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libcap >=2.78,<2.79.0a0
+  size: 124306
+  timestamp: 1786025967663
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
   build_number: 6
   sha256: d98a39a8e61af301bf67bf3fb946baff9686864886560cdd48d5259c080c58a5
@@ -10907,6 +11118,31 @@ packages:
   run_exports: {}
   size: 77856
   timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.6.0-ha770c72_0.conda
+  sha256: 45bb0eb92000a3f82555cc948013935aace8a1ea522b79700f58d3906c18e846
+  md5: b04e60c49d09399a009f3bb70bb53a23
+  depends:
+  - libfabric1 2.6.0 h6b3ec72_0
+  license: BSD-2-Clause OR GPL-2.0-only
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 14365
+  timestamp: 1782364120544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.6.0-h6b3ec72_0.conda
+  sha256: ba8de6a838bc0727ef8e5a1409c6735465b7b582627a9b4c2704126e53903f43
+  md5: 7d8c510157360d0a6fdd84a1d3db8de7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libnl >=3.11.0,<4.0a0
+  - rdma-core >=63.0
+  license: BSD-2-Clause OR GPL-2.0-only
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 734920
+  timestamp: 1782364119825
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -11681,6 +11917,20 @@ packages:
     - libnghttp2 >=1.68.1,<2.0a0
   size: 663344
   timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
+  sha256: d0f2fd77aad83641c11bc3686bac677e99869f1d62b99e5064c9d99af8bfde6a
+  md5: eeaf53e3c9593d63ffee5ad97182858e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - libnl >=3.11.0,<4.0a0
+  size: 735004
+  timestamp: 1787038268022
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
   md5: d864d34357c3b65a4b731f78c0801dc4
@@ -11872,6 +12122,40 @@ packages:
     - libpciaccess >=0.19,<0.20.0a0
   size: 30070
   timestamp: 1785971678815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h31fc519_4.conda
+  sha256: 2837759fb832ab8587622602531f8e4b5d5e5ec12ea9b3936be06f384b933800
+  md5: bd15ae3916a0cbe005c683bbc33811b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=14
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libpmix >=5.0.8,<6.0a0
+  size: 731098
+  timestamp: 1770962978877
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h4bd6b51_2.conda
+  sha256: f36cbd91007f793654a4b7190622dbfba9e08f563faf1f6923867b4cf8e9cf97
+  md5: a79391da87ae92920508c25b6c1a7e1c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=14
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libpmix >=5.0.8,<6.0a0
+  size: 730628
+  timestamp: 1754762323076
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
   sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
   md5: eba48a68a1a2b9d3c0d9511548db85db
@@ -12141,6 +12425,18 @@ packages:
     - libstdcxx
   size: 28253
   timestamp: 1785375500257
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
+  sha256: 2293884d59cf0436c37fc0a4bad71011a8de2a6913610d1c701a7703377c1f75
+  md5: ea0da9c20bbb221b530810c3c68bbe62
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.78,<2.79.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports: {}
+  size: 493022
+  timestamp: 1780084748140
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
   sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
   md5: b6e326fbe1e3948da50ec29cee0380db
@@ -12247,6 +12543,18 @@ packages:
     - libtorch >=2.13.0,<2.14.0a0
   size: 60881910
   timestamp: 1786374025450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
+  sha256: 287d05680e49eea51b8145fbf34bc213c0618b04f32e450e9da5d715e5134e38
+  md5: 89e5671a076d99516a6acd72a35b1640
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.78,<2.79.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports: {}
+  size: 145969
+  timestamp: 1780084753104
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
   sha256: ecbf4b7520296ed580498dc66a72508b8a79da5126e1d6dc650a7087171288f9
   md5: 1247168fe4a0b8912e3336bccdbf98a5
@@ -12981,6 +13289,90 @@ packages:
     - mpfr >=4.2.2,<5.0a0
   size: 730422
   timestamp: 1773413915171
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-impi.conda
+  sha256: c01194d779d9053dd3748e7b4e5337382df8656b587ebc291bee9f3a5316f8dc
+  md5: 39f492b9ff8543bc991c543484a8bb93
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6529
+  timestamp: 1698265214566
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py311h6c43bbb_100.conda
+  sha256: bb13575ed5c527d2f24e927ae774cd73520f36d4cae85295a177a66629287fac
+  md5: 475463e0243eb6104634eef5dd7c27be
+  depends:
+  - python
+  - mpich >=3.4
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpi4py?source=hash-mapping
+  run_exports:
+    weak:
+    - mpi4py >=4.1.2,<5.0a0
+  size: 890337
+  timestamp: 1778930335676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py312h18f78f0_100.conda
+  sha256: a5e430c3021277c9cfcec79f6704c52f18735632caa6c0acca11e5cff7d44176
+  md5: a89c4978241224f652f0d3c90674d503
+  depends:
+  - python
+  - impi_rt >=2021.10
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpi4py?source=hash-mapping
+  run_exports:
+    weak:
+    - mpi4py >=4.1.2,<5.0a0
+  size: 885794
+  timestamp: 1778930332754
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.2-py313h276263e_100.conda
+  sha256: 58176b1d1778b625460107f753e46851ba19e19cc48206284633ecc8b74873ff
+  md5: a5599fd1f1ff149126aac23c936b4004
+  depends:
+  - python
+  - openmpi >=4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpi4py?source=hash-mapping
+  run_exports:
+    weak:
+    - mpi4py >=4.1.2,<5.0a0
+  size: 866184
+  timestamp: 1778930333740
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-hfbb40bb_4.conda
+  sha256: 63cd7fb6a60ed5851e070f864a5ec5109ba23dedbfe04e785fab8aff9fd7031a
+  md5: 5458b0034085c2c78865f67667b9d189
+  depends:
+  - mpi 1.0.* mpich
+  - libstdcxx >=15
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - libgfortran5 >=15.3.0
+  - libgfortran
+  - libfabric
+  - libfabric1 >=1.14.0
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  - ucx >=1.22.0,<1.23.0a0
+  license: LicenseRef-MPICH
+  purls: []
+  run_exports:
+    weak:
+    - mpich >=5.0,<6.0a0
+  size: 10061895
+  timestamp: 1787141874465
 - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py311h3778330_0.conda
   sha256: 9f3d7b8d3543f667a2a918e4ac401d98fde65c874e08eb201a41ac735f8d9797
   md5: 657ac3fca589a3da15a287868a146524
@@ -13026,6 +13418,54 @@ packages:
   run_exports: {}
   size: 99374
   timestamp: 1771610936898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py311haee01d2_0.conda
+  sha256: dbf8a085a5399e0ae4a268f00e470afdf947061ede490310ed592c1a34fcb078
+  md5: b6888ef1d9e7a71fb945b1fb9012c9e2
+  depends:
+  - python
+  - dill >=0.4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  run_exports: {}
+  size: 370828
+  timestamp: 1769086758121
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
+  sha256: 12e6f7a136ddd7e254d79e18f8815d268967a22e66617b377599fe51dc1269f6
+  md5: 7efbcffe0c84f219ae981478106c55f5
+  depends:
+  - python
+  - dill >=0.4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  run_exports: {}
+  size: 368525
+  timestamp: 1769086764893
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py313h54dd161_0.conda
+  sha256: eb5cdefc547d923706280647ac95c3a3bd5220ca17419b4c4c6eb7f0f7179c62
+  md5: 46c688f6a6e3d7ffa7a7e4d8f3045f1f
+  depends:
+  - python
+  - dill >=0.4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  run_exports: {}
+  size: 384227
+  timestamp: 1769086756827
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
   sha256: 9c2e3f9e9883e4b8d7e9e6abf7b235dc00bdcd5ef66640a360464a9f5756294d
   md5: 94116b69829e90b72d566e64421e1bff
@@ -13446,6 +13886,68 @@ packages:
     - openldap >=2.6.13,<2.7.0a0
   size: 786149
   timestamp: 1775741359582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.10-hee33aa4_2.conda
+  sha256: 20cafe96c3159bd328886552c45561dd52b6cdb844170c54189a1860a88d7997
+  md5: 7a082f0e3fe2002e187798fd2ed6b1de
+  depends:
+  - mpi 1.0.* openmpi
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgfortran5 >=14.4.0
+  - libgfortran
+  - __glibc >=2.17,<3.0.a0
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libpmix >=5.0.8,<6.0a0
+  - libnl >=3.11.0,<4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - ucx >=1.22.0,<1.23.0a0
+  - ucc >=1.8.0,<2.0a0
+  - libfabric
+  - libfabric1 >=1.14.0
+  constrains:
+  - __cuda >=12.0
+  - cuda-version >=12.0
+  - libprrte ==0.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - openmpi >=5.0.10,<6.0a0
+  size: 3948388
+  timestamp: 1787493907828
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.8-h2fe1745_110.conda
+  sha256: 4f7eb20a3ca68bdbb5ffed23cf9f31ad246b02eea03260ed8ca36e080136a8d5
+  md5: 8210e714c4369b77dd5ca9415701d87f
+  depends:
+  - mpi 1.0.* openmpi
+  - libgfortran5 >=14.3.0
+  - libgfortran
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libpmix >=5.0.8,<6.0a0
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - ucx >=1.19.1,<1.20.0a0
+  - libfabric
+  - libfabric1 >=1.14.0
+  - ucc >=1.6.0,<2.0a0
+  - libnl >=3.11.0,<4.0a0
+  constrains:
+  - __cuda >=12.0
+  - cuda-version >=12.0
+  - libprrte ==0.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - openmpi >=5.0.8,<6.0a0
+  size: 3926005
+  timestamp: 1766182470682
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
   sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
   md5: c5955c27917ff2234def47f075e71e02
@@ -15552,6 +16054,24 @@ packages:
   run_exports: {}
   size: 100581
   timestamp: 1764015033819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
+  sha256: 93e53eeaf6e7b8d2c349cd52005720aaceb47e7ead0a741290567b2907e3a42d
+  md5: 0aefd461ece5a4a2043ca5aae5da6c22
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libnl >=3.11.0,<4.0a0
+  - libstdcxx >=14
+  - libsystemd0 >=257.13
+  - libudev1 >=257.13
+  license: Linux-OpenIB
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - rdma-core >=63.1
+  size: 1282047
+  timestamp: 1787577665305
 - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
   sha256: 2f225ddf4a274743045aded48053af65c31721e797a45beed6774fdc783febfb
   md5: 0227d04521bc3d28c7995c7e1f99a721
@@ -15702,6 +16222,54 @@ packages:
     - s2n >=1.7.6,<1.7.7.0a0
   size: 393680
   timestamp: 1784674401024
+- conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py311h38be061_2.conda
+  sha256: 856b287ab0ef1775ab75a99c5375ec9d98535c2059d3aebfbad3293908b97129
+  md5: 304080779870da475480ae03378def56
+  depends:
+  - dill
+  - mpi4py
+  - multiprocess
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/schwimmbad?source=hash-mapping
+  run_exports: {}
+  size: 32844
+  timestamp: 1756821339983
+- conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py312h7900ff3_2.conda
+  sha256: ac88a43cbd1f50722e8ef5b36923c9ea8df3e94d764618a4f7dfdaa3b64bfbe3
+  md5: 7b78dac88e6619a78dbf0cad9aab9775
+  depends:
+  - dill
+  - mpi4py
+  - multiprocess
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/schwimmbad?source=hash-mapping
+  run_exports: {}
+  size: 32183
+  timestamp: 1756821396033
+- conda: https://conda.anaconda.org/conda-forge/linux-64/schwimmbad-0.4.2-py313h78bf25f_2.conda
+  sha256: fee316a5324e48bc0ff1eb40de8b9d1dcc83ac151c2046481c2ec6af4d808598
+  md5: 1a303f47ca15c8f805f1125dbe4c3b44
+  depends:
+  - dill
+  - mpi4py
+  - multiprocess
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/schwimmbad?source=hash-mapping
+  run_exports: {}
+  size: 33106
+  timestamp: 1756821421027
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py311ha15b03d_0.conda
   sha256: 8d9c2c1d676091fcbc04c8419d8d0b474c5019df07531e7fb4860c94466c4c1d
   md5: 7f2415bac058bf107a28457fcc2989e7
@@ -16057,6 +16625,87 @@ packages:
   run_exports: {}
   size: 923237
   timestamp: 1786226770518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.6.0-hb729f83_1.conda
+  sha256: b8c44092307284004cd45469a5f7c146dc8d1639e1123cf52c4398c47261d538
+  md5: df5c1d82bfc9294180f9893b62bdb1df
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - ucx >=1.19.1,<1.19.2.0a0
+  constrains:
+  - cuda-cudart
+  - cuda-version >=12,<13.0a0
+  - nccl >=2.28.9.1,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - ucc >=1.6.0,<2.0a0
+  size: 8769799
+  timestamp: 1765333931927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ucc-1.8.0-h539fd1b_2.conda
+  sha256: 073f75becf0aade3d7a6606609630dd0fef1aa37a9a73a34c8c7ced6b75c5b2e
+  md5: 9594197df79eb266bf52f4e5d1407d6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - rdma-core >=63.0
+  - ucx >=1.22.0,<1.22.1.0a0
+  constrains:
+  - cuda-cudart
+  - cuda-version >=12,<13.0a0
+  - nccl >=2.30.7.1,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - ucc >=1.8.0,<2.0a0
+  size: 12957132
+  timestamp: 1785867959443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.19.1-h567e125_0.conda
+  sha256: f517d76abfdf47feb6747d48c4a346b031f103a376bafe9880b618b44766f7c3
+  md5: ebddc06816f6da025819151f34dcb070
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - rdma-core >=60.0
+  constrains:
+  - cuda-version >=13,<14.0a0
+  - cuda-cudart
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - ucx >=1.19.1,<1.20.0a0
+  size: 7688501
+  timestamp: 1765148670053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.22.0-hb659a20_0.conda
+  sha256: 97e6f7a2a7341f3dabd584389b24e58e3983445f0a11f5b11f73f947da443ad2
+  md5: df26bd65c3b0060349578809f75ce63b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - rdma-core >=63.0
+  constrains:
+  - cuda-cudart
+  - cuda-version >=12,<13.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - ucx >=1.22.0,<1.23.0a0
+  size: 9572007
+  timestamp: 1785789452621
 - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
   sha256: 2bd8ee058dc98e614003591eb221a8b08449768b13aebe76dad8528bf0f5f88b
   md5: 2889f0c0b6a6d7a37bd64ec60f4cc210
@@ -18586,6 +19235,24 @@ packages:
   run_exports: {}
   size: 93811
   timestamp: 1784722859728
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
+  sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
+  md5: 1052de900d672ec8b3713b8e300a8f06
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6522
+  timestamp: 1727683134241
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-openmpi.conda
+  sha256: e1698675ec83a2139c0b02165f47eaf0701bcab043443d9008fc0f8867b07798
+  md5: 78b827d2852c67c68cd5b2c55f31e376
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6571
+  timestamp: 1727683130230
 - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
   sha256: 5bbf2f8179ec43d34d67ca8e4989d216c1bdb4b749fe6cb40e86ebf88c1b5300
   md5: 2e81b32b805f406d23ba61938a184081
@@ -21616,7 +22283,7 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   purls:
-  - pkg:pypi/coverage?source=compressed-mapping
+  - pkg:pypi/coverage?source=hash-mapping
   run_exports: {}
   size: 414190
   timestamp: 1786292802679
@@ -22921,6 +23588,28 @@ packages:
   run_exports: {}
   size: 69362
   timestamp: 1781203631990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.6.0-hce30654_0.conda
+  sha256: 048eb6e03202b5a6f8ecbcdeb5a3f5ac9702736aa494de6615639d60ff68adc9
+  md5: b92a04dd36f41b0d8dfed62ff7812eea
+  depends:
+  - libfabric1 2.6.0 h84a0fba_0
+  license: BSD-2-Clause OR GPL-2.0-only
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 14461
+  timestamp: 1782364775970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.6.0-h84a0fba_0.conda
+  sha256: 267ab5fe990209b33de220432bcb595a88e6bb642e282bbe433a8edfdc811c1a
+  md5: 5b0d1d64a7fe7e86900dd1859d2dd4d4
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause OR GPL-2.0-only
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 334671
+  timestamp: 1782364772938
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
   sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
   md5: 43c04d9cb46ef176bb2a4c77e324d599
@@ -23149,6 +23838,22 @@ packages:
   run_exports: {}
   size: 942277
   timestamp: 1785770026085
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.13.0-default_ha97f43a_1000.conda
+  sha256: d47c3c030671d196ff1cdd343e93eb2ae0d7b665cb79f8164cc91488796db437
+  md5: fed55ddd65a830cb62e78f07cfffcd41
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libhwloc >=2.13.0,<2.13.1.0a0
+  size: 2339152
+  timestamp: 1770953916323
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
   sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
   md5: 4d5a7445f0b25b6a3ddbb56e790f5251
@@ -23432,6 +24137,22 @@ packages:
     - libparquet >=25.0.0,<25.1.0a0
   size: 1096341
   timestamp: 1786315419506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-hddb0edd_4.conda
+  sha256: 038b7e32614e0e7e64507546e87211aec06ecde87b700749b2765d9a9c2f35c8
+  md5: bb2e44b80f8b1fb78b846f3e3239efc4
+  depends:
+  - __osx >=11.0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libpmix >=5.0.8,<6.0a0
+  size: 530391
+  timestamp: 1770963627741
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
   sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   md5: 2259ae0949dbe20c0665850365109b27
@@ -24174,6 +24895,60 @@ packages:
     - mpfr >=4.2.2,<5.0a0
   size: 348767
   timestamp: 1773414111071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py311h61b4f52_100.conda
+  sha256: 9dea8f5a687e85446323e4523c136080515236927d8283e596da10ab500447c1
+  md5: 4d4eab795aed7048ab15d3549772462f
+  depends:
+  - python
+  - openmpi >=4.1
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpi4py?source=hash-mapping
+  run_exports:
+    weak:
+    - mpi4py >=4.1.2,<5.0a0
+  size: 744849
+  timestamp: 1778930589711
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py312h50e9609_100.conda
+  sha256: e3efbdf631e6a54aefd03b23cd5eefec9ab3a228e50d3fd520877eaebfde41cd
+  md5: 90862d094fbe045ffba84db96af6c2fd
+  depends:
+  - python
+  - openmpi >=4.1
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpi4py?source=hash-mapping
+  run_exports:
+    weak:
+    - mpi4py >=4.1.2,<5.0a0
+  size: 751137
+  timestamp: 1778930573954
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi4py-4.1.2-py313h19173f3_100.conda
+  sha256: 5a4bc2e980bfb1726041d0400207069c5aa413d7e692c32423c6c5ea55d4336d
+  md5: 977afddb4604e2deef18150559d5883b
+  depends:
+  - python
+  - openmpi >=4.1
+  - __osx >=11.0
+  - python 3.13.* *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpi4py?source=hash-mapping
+  run_exports:
+    weak:
+    - mpi4py >=4.1.2,<5.0a0
+  size: 758735
+  timestamp: 1778930581933
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py311ha275503_0.conda
   sha256: 01aae5d525f7eec07bfe9d9cd82cae84d5889babdfe4bd3b674b734005289cfe
   md5: a57b7e57a380097482d5a89a44f0a5c4
@@ -24219,6 +24994,54 @@ packages:
   run_exports: {}
   size: 87067
   timestamp: 1771611311391
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py311he363849_0.conda
+  sha256: 7dd4bf2cdab76d3c798b7a2d72561cc186b375dbcf5eb89a1d85f1e984efad84
+  md5: fd13d7194b400f144f8604c057b177a2
+  depends:
+  - python
+  - dill >=0.4.1
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  run_exports: {}
+  size: 374076
+  timestamp: 1769086898989
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py312hb3ab3e3_0.conda
+  sha256: e6684816e5cd74b664ba2adbcfdbfa9434702690a2ba10f62ed41566ed5b38d1
+  md5: 7aa7f3104e4fe84565e0b9a77086736f
+  depends:
+  - python
+  - dill >=0.4.1
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  run_exports: {}
+  size: 371957
+  timestamp: 1769086875473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py313h6688731_0.conda
+  sha256: adffa67bb1960203cd9cc89ec79ba93a0aa062a8bd7bf81f321022f9f9fd5f99
+  md5: 6dd40224216c5ff748f99823ddb7afd4
+  depends:
+  - python
+  - dill >=0.4.1
+  - __osx >=11.0
+  - python 3.13.* *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  run_exports: {}
+  size: 387889
+  timestamp: 1769087014007
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
   sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
   md5: 3dfa0d0316dc246cd44937a557de4501
@@ -24526,6 +25349,31 @@ packages:
     - openjpeg >=2.5.4,<3.0a0
   size: 319697
   timestamp: 1772625397692
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.10-h07cac57_1.conda
+  sha256: b9fd17b74b6698c6878ee91c73d62eb27d4785f79e2817a55aec1817b1329e48
+  md5: a889e6877364e3f7989bb2070659d76f
+  depends:
+  - mpi 1.0.* openmpi
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - __osx >=11.0
+  - libcxx >=19
+  - libhwloc >=2.13.0,<2.13.1.0a0
+  - libpmix >=5.0.8,<6.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libfabric
+  - libfabric1 >=1.14.0
+  constrains:
+  - libprrte ==0.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - openmpi >=5.0.10,<6.0a0
+  size: 2594948
+  timestamp: 1772089733369
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
   sha256: 66be2283b5b37dcda1332b5e74c1782a8cb14fd2e62e0d38017c2d35bf73c119
   md5: 65d1906712b85d1679263c518d011b5b
@@ -26267,6 +27115,57 @@ packages:
     - s2n >=1.7.6,<1.7.7.0a0
   size: 277238
   timestamp: 1784674786218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py311h267d04e_2.conda
+  sha256: 72f87db2953db0d7bf1d70f3b89271cbcb513c98aa469926304480b899183183
+  md5: 6da14d2d53e4b3ce6db88149a7e80933
+  depends:
+  - dill
+  - mpi4py
+  - multiprocess
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/schwimmbad?source=hash-mapping
+  run_exports: {}
+  size: 33427
+  timestamp: 1756821625244
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py312h81bd7bf_2.conda
+  sha256: 67716c0428ad8bb17d10cf264d6d7662f85aad30e6b9761cb7e761de855f903f
+  md5: 36156fcf1484f7627e4510fb87115152
+  depends:
+  - dill
+  - mpi4py
+  - multiprocess
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/schwimmbad?source=hash-mapping
+  run_exports: {}
+  size: 32726
+  timestamp: 1756821641869
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/schwimmbad-0.4.2-py313h8f79df9_2.conda
+  sha256: 93b26833942ce59b740e948bf21e544383928f04ff24822655086ae1f0085e71
+  md5: 0a7455f2c7a086c4c3ee88eed6d0991a
+  depends:
+  - dill
+  - mpi4py
+  - multiprocess
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/schwimmbad?source=hash-mapping
+  run_exports: {}
+  size: 33644
+  timestamp: 1756821470620
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py311hf1dd2ad_0.conda
   sha256: 65772371eb10e008576d22a52982517153958e08c2cb64971bbd6e499ee65498
   md5: f4c90a74c14bbbb86e1ae8f8526d75f8

--- a/pixi.toml
+++ b/pixi.toml
@@ -94,6 +94,7 @@ pytest-doctestplus = "*"
 pytest-requires = "*"
 pytest-rerunfailures = "*"
 pytorch-cpu = "*"
+schwimmbad = "*"
 scikit-learn = "*"
 
 [feature.test.pypi-dependencies]

--- a/test/bilby_mcmc/test_sampler.py
+++ b/test/bilby_mcmc/test_sampler.py
@@ -44,7 +44,7 @@ class TestBilbyMCMCSampler(unittest.TestCase):
         search_parameter_keys = ['m', 'c']
         use_ratio = False
 
-        bilby.core.sampler.base_sampler._initialize_global_variables(
+        bilby.core.sampler.base_sampler.initialize_global_variables(
             likelihood,
             priors,
             search_parameter_keys,

--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -880,7 +880,7 @@ class TestReweight(unittest.TestCase):
             log_evidence=-np.log(10),
         )
 
-    def _run_reweighting(self, sigma):
+    def _run_reweighting(self, sigma, npool=None):
         likelihood_1 = SimpleGaussianLikelihood()
         likelihood_2 = SimpleGaussianLikelihood(sigma=sigma)
         original_ln_likelihoods = list()
@@ -890,7 +890,11 @@ class TestReweight(unittest.TestCase):
         self.result.posterior["log_likelihood"] = original_ln_likelihoods
         self.original_ln_likelihoods = original_ln_likelihoods
         return bilby.core.result.reweight(
-            self.result, likelihood_1, likelihood_2, verbose_output=True
+            self.result,
+            likelihood_1,
+            likelihood_2,
+            verbose_output=True,
+            npool=npool,
         )
 
     def test_reweight_same_likelihood_weights_1(self):
@@ -898,6 +902,13 @@ class TestReweight(unittest.TestCase):
         When the likelihoods are the same, the weights should be 1.
         """
         _, weights, _, _, _, _ = self._run_reweighting(sigma=1)
+        self.assertLess(min(abs(weights - 1)), 1e-10)
+
+    def test_reweight_same_likelihood_weights_1_with_pool(self):
+        """
+        When the likelihoods are the same, the weights should be 1.
+        """
+        _, weights, _, _, _, _ = self._run_reweighting(sigma=1, npool=2)
         self.assertLess(min(abs(weights - 1)), 1e-10)
 
     @pytest.mark.flaky(reruns=3)

--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -953,7 +953,7 @@ class TestReweight(unittest.TestCase):
             log_evidence=-np.log(10),
         )
 
-    def _run_reweighting(self, sigma):
+    def _run_reweighting(self, sigma, npool=None):
         likelihood_1 = SimpleGaussianLikelihood()
         likelihood_2 = SimpleGaussianLikelihood(sigma=sigma)
         original_ln_likelihoods = list()
@@ -963,7 +963,11 @@ class TestReweight(unittest.TestCase):
         self.result.posterior["log_likelihood"] = original_ln_likelihoods
         self.original_ln_likelihoods = original_ln_likelihoods
         return bilby.core.result.reweight(
-            self.result, likelihood_1, likelihood_2, verbose_output=True
+            self.result,
+            likelihood_1,
+            likelihood_2,
+            verbose_output=True,
+            npool=npool,
         )
 
     def test_reweight_same_likelihood_weights_1(self):
@@ -971,6 +975,13 @@ class TestReweight(unittest.TestCase):
         When the likelihoods are the same, the weights should be 1.
         """
         _, weights, _, _, _, _ = self._run_reweighting(sigma=1)
+        self.assertLess(min(abs(weights - 1)), 1e-10)
+
+    def test_reweight_same_likelihood_weights_1_with_pool(self):
+        """
+        When the likelihoods are the same, the weights should be 1.
+        """
+        _, weights, _, _, _, _ = self._run_reweighting(sigma=1, npool=2)
         self.assertLess(min(abs(weights - 1)), 1e-10)
 
     @pytest.mark.flaky(reruns=3)

--- a/test/core/sampler/dynesty_test.py
+++ b/test/core/sampler/dynesty_test.py
@@ -483,6 +483,7 @@ class TestReproducibility(unittest.TestCase):
             resume=False,
             dlogz=1.0,
             nlive=20,
+            sample="acceptance-walk",
             **kwargs,
         )
 

--- a/test/core/sampler/dynesty_test.py
+++ b/test/core/sampler/dynesty_test.py
@@ -64,7 +64,7 @@ class TestDynesty(unittest.TestCase):
             skip_import_verification=True,
             **kwargs,
         )
-        bilby.core.sampler.base_sampler._initialize_global_variables(
+        bilby.core.sampler.base_sampler.initialize_global_variables(
             self.likelihood,
             self.priors,
             self.priors.keys(),
@@ -495,6 +495,7 @@ class TestReproducibility(unittest.TestCase):
             resume=False,
             dlogz=1.0,
             nlive=20,
+            sample="acceptance-walk",
             **kwargs,
         )
 

--- a/test/integration/sampler_run_test.py
+++ b/test/integration/sampler_run_test.py
@@ -72,7 +72,7 @@ class TestRunningSamplers(unittest.TestCase):
         bilby.core.utils.check_directory_exists_and_if_not_mkdir("outdir")
 
     @staticmethod
-    def conversion_function(parameters, likelihood, prior):
+    def conversion_function(parameters, likelihood, priors):
         converted = parameters.copy()
         if "derived" not in converted:
             converted["derived"] = converted["m"] * converted["c"]

--- a/test/integration/sampler_run_test.py
+++ b/test/integration/sampler_run_test.py
@@ -8,11 +8,13 @@ multiprocessing.set_start_method("fork")  # noqa
 
 import unittest
 import pytest
-from parameterized import parameterized
 import shutil
+from parameterized import parameterized
 
 import bilby
 import numpy as np
+from bilby.core.sampler.base_sampler import initialize_global_variables
+from schwimmbad import SerialPool
 
 
 _sampler_kwargs = dict(
@@ -72,7 +74,7 @@ class TestRunningSamplers(unittest.TestCase):
         bilby.core.utils.check_directory_exists_and_if_not_mkdir("outdir")
 
     @staticmethod
-    def conversion_function(parameters, likelihood, prior):
+    def conversion_function(parameters, likelihood, priors):
         converted = parameters.copy()
         if "derived" not in converted:
             converted["derived"] = converted["m"] * converted["c"]
@@ -93,6 +95,12 @@ class TestRunningSamplers(unittest.TestCase):
     @parameterized.expand(_sampler_kwargs.keys())
     def test_run_sampler_single(self, sampler):
         self._run_sampler(sampler, pool_size=1)
+
+    @parameterized.expand(_sampler_kwargs.keys())
+    def test_run_sampler_schwimmbad(self, sampler):
+        pool = SerialPool()
+        initialize_global_variables(self.likelihood, self.priors, ["m", "c"], True, {"m": 0, "c": 0})
+        self._run_sampler(sampler, pool_size=1, pool=pool)
 
     @parameterized.expand(_sampler_kwargs.keys())
     def test_run_sampler_pool(self, sampler):
@@ -119,10 +127,16 @@ class TestRunningSamplers(unittest.TestCase):
         self._run_with_signal_handling(sampler, pool_size=1)
 
     @parameterized.expand(_sampler_kwargs.keys())
+    def test_interrupt_sampler_schwimmbad(self, sampler):
+        pool = SerialPool()
+        initialize_global_variables(self.likelihood, self.priors, ["m", "c"], True, {"m": 0, "c": 0})
+        self._run_with_signal_handling(sampler, pool_size=1, pool=pool)
+
+    @parameterized.expand(_sampler_kwargs.keys())
     def test_interrupt_sampler_pool(self, sampler):
         self._run_with_signal_handling(sampler, pool_size=2)
 
-    def _run_with_signal_handling(self, sampler, pool_size=1):
+    def _run_with_signal_handling(self, sampler, pool_size=1, **kwargs):
         pytest.importorskip(sampler_imports.get(sampler, sampler))
         if loaded_samplers[sampler.lower()].hard_exit:
             pytest.skip(f"{sampler} hard exits, can't test signal handling.")
@@ -143,7 +157,7 @@ class TestRunningSamplers(unittest.TestCase):
         with self.assertRaises((SystemExit, KeyboardInterrupt)):
             try:
                 while True:
-                    self._run_sampler(sampler=sampler, pool_size=pool_size, exit_code=5)
+                    self._run_sampler(sampler=sampler, pool_size=pool_size, exit_code=5, **kwargs)
             except SystemExit as error:
                 self.assertEqual(error.code, 5)
                 raise


### PR DESCRIPTION
I noticed that it was difficult to pass a user-specified pool through run_sampler, and it isn't used at all in the post processing. This PR:

- unifies how to create a pool for Bilby with a context (a la `with multiprocessing.pool()...`)
- explicitly passes the user pool around including for post processing
- moves logic out of `Sampler._setup_pool` and `Sampler._close_pool`
- support MPI pools using schwimmbad. This change will effectively make `parallel_bilby` moot.