### PR TITLE
FEAT: define pytrees for bilby types

### DIFF
--- a/bilby/compat/jax.py
+++ b/bilby/compat/jax.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 from ..core.likelihood import Likelihood
+from . import pytrees  # noqa
 
 
 class JittedLikelihood(Likelihood):

--- a/bilby/compat/pytrees/__init__.py
+++ b/bilby/compat/pytrees/__init__.py
@@ -1,0 +1,5 @@
+# noqa
+
+from . import likelihood
+from . import prior
+from . import utils

--- a/bilby/compat/pytrees/likelihood.py
+++ b/bilby/compat/pytrees/likelihood.py
@@ -127,13 +127,17 @@ def joint_likelihood_unflatten(aux_data, flat) -> JointLikelihood:
     return likelihood
 
 
-def analytical_multidimensional_covariant_gaussian_flatten(likelihood: AnalyticalMultidimensionalCovariantGaussian):
+def analytical_multidimensional_covariant_gaussian_flatten(
+    likelihood: AnalyticalMultidimensionalCovariantGaussian
+):
     _, aux_data = likelihood_flatten(likelihood)
     children = (likelihood.cov, likelihood.mean, likelihood.sigma)
     return children, aux_data
 
 
-def analytical_multidimensional_covariant_gaussian_unflatten(aux_data, flat) -> AnalyticalMultidimensionalCovariantGaussian:
+def analytical_multidimensional_covariant_gaussian_unflatten(
+    aux_data, flat
+) -> AnalyticalMultidimensionalCovariantGaussian:
     likelihood = likelihood_unflatten(aux_data, flat)
     cov, mean, sigma = flat
     likelihood.cov = cov
@@ -143,13 +147,17 @@ def analytical_multidimensional_covariant_gaussian_unflatten(aux_data, flat) -> 
     return likelihood
 
 
-def analytical_multidimensional_bimodal_covariant_gaussian_flatten(likelihood: AnalyticalMultidimensionalBimodalCovariantGaussian):
+def analytical_multidimensional_bimodal_covariant_gaussian_flatten(
+    likelihood: AnalyticalMultidimensionalBimodalCovariantGaussian
+):
     _, aux_data = likelihood_flatten(likelihood)
     children = (likelihood.cov, likelihood.mean_1, likelihood.mean_2, likelihood.sigma)
     return children, aux_data
 
 
-def analytical_multidimensional_bimodal_covariant_gaussian_unflatten(aux_data, flat) -> AnalyticalMultidimensionalBimodalCovariantGaussian:
+def analytical_multidimensional_bimodal_covariant_gaussian_unflatten(
+    aux_data, flat
+) -> AnalyticalMultidimensionalBimodalCovariantGaussian:
     likelihood = likelihood_unflatten(aux_data, flat)
     cov, mean_1, mean_2, sigma = flat
     likelihood.cov = cov
@@ -171,7 +179,15 @@ for tpl in [
     (StudentTLikelihood, student_t_likelihood_flatten, student_t_likelihood_unflatten),
     (Multinomial, multinomial_flatten, multinomial_unflatten),
     (JointLikelihood, joint_likelihood_flatten, joint_likelihood_unflatten),
-    (AnalyticalMultidimensionalCovariantGaussian, analytical_multidimensional_covariant_gaussian_flatten, analytical_multidimensional_covariant_gaussian_unflatten),
-    (AnalyticalMultidimensionalBimodalCovariantGaussian, analytical_multidimensional_bimodal_covariant_gaussian_flatten, analytical_multidimensional_bimodal_covariant_gaussian_unflatten),
+    (
+        AnalyticalMultidimensionalCovariantGaussian,
+        analytical_multidimensional_covariant_gaussian_flatten,
+        analytical_multidimensional_covariant_gaussian_unflatten,
+    ),
+    (
+        AnalyticalMultidimensionalBimodalCovariantGaussian,
+        analytical_multidimensional_bimodal_covariant_gaussian_flatten,
+        analytical_multidimensional_bimodal_covariant_gaussian_unflatten,
+    ),
 ]:
     register_pytree_node(*tpl)

--- a/bilby/compat/pytrees/likelihood.py
+++ b/bilby/compat/pytrees/likelihood.py
@@ -1,0 +1,177 @@
+from functools import partial
+
+import jax
+from jax.tree_util import register_pytree_node
+
+from ...core.likelihood import (
+    Likelihood,
+    Analytical1DLikelihood,
+    AnalyticalMultidimensionalBimodalCovariantGaussian,
+    AnalyticalMultidimensionalCovariantGaussian,
+    ExponentialLikelihood,
+    GaussianLikelihood,
+    JointLikelihood,
+    Multinomial,
+    PoissonLikelihood,
+    StudentTLikelihood,
+    ZeroLikelihood,
+)
+
+
+def likelihood_flatten(likelihood: Likelihood):
+    children = ()
+    aux_data = (
+        likelihood.__class__,
+        likelihood._marginalized_parameters,
+    )
+    return children, aux_data
+
+
+def likelihood_unflatten(aux_data, flat) -> Likelihood:
+    likelihood_cls, marginalized_parameters = aux_data[:2]
+    likelihood = likelihood_cls.__new__(likelihood_cls)
+    likelihood._marginalized_parameters = marginalized_parameters
+    likelihood._parameters = dict()
+    return likelihood
+
+
+def zero_likelihood_flatten(likelihood: ZeroLikelihood):
+    _, aux_data = likelihood_flatten(likelihood)
+    children = (likelihood._parent,)
+    return children, aux_data
+
+
+def zero_likelihood_unflatten(aux_data, flat) -> ZeroLikelihood:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    parent = flat[0]
+    likelihood._parent = parent
+    return likelihood
+
+
+def analytical_1d_likelihood_flatten(likelihood: Analytical1DLikelihood):
+    _, aux_data = likelihood_flatten(likelihood)
+    children = (likelihood._x, likelihood._y)
+    aux_data += (likelihood._func, likelihood._function_keys, likelihood.kwargs)
+    return children, aux_data
+
+
+def analytical_1d_likelihood_unflatten(aux_data, flat) -> Analytical1DLikelihood:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    func, function_keys, kwargs = aux_data[2:5]
+    likelihood._func = func
+    likelihood._function_keys = function_keys
+    likelihood.kwargs = kwargs
+    x, y = flat[:2]
+    likelihood._x = x
+    likelihood._y = y
+    return likelihood
+
+
+def gaussian_likelihood_flatten(likelihood: GaussianLikelihood):
+    children, aux_data = analytical_1d_likelihood_flatten(likelihood)
+    children += (likelihood._sigma,)
+    return children, aux_data
+
+
+def gaussian_likelihood_unflatten(aux_data, flat) -> GaussianLikelihood:
+    likelihood = analytical_1d_likelihood_unflatten(aux_data, flat)
+    sigma = flat[2]
+    likelihood._sigma = sigma
+    return likelihood
+
+
+def student_t_likelihood_flatten(likelihood: StudentTLikelihood):
+    children, aux_data = analytical_1d_likelihood_flatten(likelihood)
+    children += (likelihood.sigma,)
+    aux_data += (likelihood._nu,)
+    return children, aux_data
+
+
+def student_t_likelihood_unflatten(aux_data, flat) -> StudentTLikelihood:
+    likelihood = analytical_1d_likelihood_unflatten(aux_data, flat)
+    sigma = flat[2]
+    nu = aux_data[5]
+    likelihood._nu = nu
+    likelihood.sigma = sigma
+    return likelihood
+
+
+def multinomial_flatten(likelihood: Multinomial):
+    children, aux_data = likelihood_flatten(likelihood)
+    children += (likelihood.data, likelihood._total, likelihood._nll)
+    aux_data += (likelihood.n, likelihood.base)
+    return children, aux_data
+
+
+def multinomial_unflatten(aux_data, flat) -> Multinomial:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    data, total, nll = flat[:3]
+    n, base = aux_data[2:4]
+    likelihood.data = data
+    likelihood._total = total
+    likelihood._nll = nll
+    likelihood.n = n
+    likelihood.base = base
+    return likelihood
+
+
+def joint_likelihood_flatten(likelihood: JointLikelihood):
+    children = tuple(likelihood._likelihoods)
+    _, aux_data = likelihood_flatten(likelihood)
+    return children, aux_data
+
+
+def joint_likelihood_unflatten(aux_data, flat) -> JointLikelihood:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    likelihood._likelihoods = list(flat)
+    return likelihood
+
+
+def analytical_multidimensional_covariant_gaussian_flatten(likelihood: AnalyticalMultidimensionalCovariantGaussian):
+    _, aux_data = likelihood_flatten(likelihood)
+    children = (likelihood.cov, likelihood.mean, likelihood.sigma)
+    return children, aux_data
+
+
+def analytical_multidimensional_covariant_gaussian_unflatten(aux_data, flat) -> AnalyticalMultidimensionalCovariantGaussian:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    cov, mean, sigma = flat
+    likelihood.cov = cov
+    likelihood.mean = mean
+    likelihood.sigma = sigma
+    likelihood.logpdf = partial(jax.scipy.stats.multivariate_normal.logpdf, mean=mean, cov=cov)
+    return likelihood
+
+
+def analytical_multidimensional_bimodal_covariant_gaussian_flatten(likelihood: AnalyticalMultidimensionalBimodalCovariantGaussian):
+    _, aux_data = likelihood_flatten(likelihood)
+    children = (likelihood.cov, likelihood.mean_1, likelihood.mean_2, likelihood.sigma)
+    return children, aux_data
+
+
+def analytical_multidimensional_bimodal_covariant_gaussian_unflatten(aux_data, flat) -> AnalyticalMultidimensionalBimodalCovariantGaussian:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    cov, mean_1, mean_2, sigma = flat
+    likelihood.cov = cov
+    likelihood.mean_1 = mean_1
+    likelihood.mean_2 = mean_2
+    likelihood.sigma = sigma
+    likelihood.logpdf_1 = partial(jax.scipy.stats.multivariate_normal.logpdf, mean=mean_1, cov=cov)
+    likelihood.logpdf_2 = partial(jax.scipy.stats.multivariate_normal.logpdf, mean=mean_2, cov=cov)
+    return likelihood
+
+
+for tpl in [
+    (Likelihood, likelihood_flatten, likelihood_unflatten),
+    (GaussianLikelihood, gaussian_likelihood_flatten, gaussian_likelihood_unflatten),
+    (ZeroLikelihood, zero_likelihood_flatten, zero_likelihood_unflatten),
+    (Analytical1DLikelihood, analytical_1d_likelihood_flatten, analytical_1d_likelihood_unflatten),
+    (PoissonLikelihood, analytical_1d_likelihood_flatten, analytical_1d_likelihood_unflatten),
+    (ExponentialLikelihood, analytical_1d_likelihood_flatten, analytical_1d_likelihood_unflatten),
+    (StudentTLikelihood, student_t_likelihood_flatten, student_t_likelihood_unflatten),
+    (Multinomial, multinomial_flatten, multinomial_unflatten),
+    (JointLikelihood, joint_likelihood_flatten, joint_likelihood_unflatten),
+    (AnalyticalMultidimensionalCovariantGaussian, analytical_multidimensional_covariant_gaussian_flatten, analytical_multidimensional_covariant_gaussian_unflatten),
+    (AnalyticalMultidimensionalBimodalCovariantGaussian, analytical_multidimensional_bimodal_covariant_gaussian_flatten, analytical_multidimensional_bimodal_covariant_gaussian_unflatten),
+]:
+    register_pytree_node(*tpl)

--- a/bilby/compat/pytrees/prior.py
+++ b/bilby/compat/pytrees/prior.py
@@ -1,0 +1,159 @@
+from jax.tree_util import register_pytree_node
+
+from ...core.prior.analytical import *
+from ...core.prior.base import Prior
+from ...core.prior.conditional import *
+from ...core.prior.dict import PriorDict, ConditionalPriorDict, DirichletPriorDict
+from ...core.prior.interpolated import Interped, FromFile
+from ...core.prior.slabspike import SlabSpikePrior
+from ...gw.prior import *
+
+
+def prior_flatten(prior: Prior):
+    props = prior.get_instantiation_dict()
+    for key in ["name", "unit", "latex_label", "_boundary", "_minimum", "_maximum"]:
+        if key not in props and key.strip("_") not in props:
+            props[key] = getattr(prior, key, None)
+    child_props = dict()
+    for key in prior._leaves:
+        if key in props:
+            child_props[key] = props.pop(key)
+        elif key.strip("_") in props:
+            child_props[key] = props.pop(key.strip("_"))
+        else:
+            child_props[key] = getattr(prior, key)
+    aux_props = {key: props[key] for key in set(props.keys()).difference(prior._leaves)}
+    children = (prior.least_recently_sampled, child_props)
+    aux_data = (prior.__class__, prior.is_fixed, aux_props)
+    # print(prior, children, aux_data)
+    return children, aux_data
+
+
+def prior_unflatten(aux_data, children) -> Prior:
+    cls, is_fixed, aux_props = aux_data
+    least_recently_sampled, child_props = children
+    prior = cls.__new__(cls)
+    prior._is_fixed = is_fixed
+    prior.least_recently_sampled = least_recently_sampled
+    for key in ["name", "unit", "latex_label", "_boundary"]:
+        if key in aux_props:
+            setattr(prior, key, aux_props.pop(key))
+    for k, v in child_props.items():
+        setattr(prior, k, v)
+    for k, v in aux_props.items():
+        setattr(prior, k, v)
+    # print(prior)
+    return prior
+
+
+def conditional_flatten(prior: ConditionalBasePrior):
+    children, aux_data = prior_flatten(prior)
+
+    children += (prior._reference_params,)
+
+    aux_data += (prior._required_variables, prior._condition_func)
+
+    return children, aux_data
+
+
+def conditional_unflatten(aux_data, children) -> ConditionalBasePrior:
+    prior = prior_unflatten(aux_data[:3], children[:2])
+    reference_params = children[2]
+    required_variables, condition_func = aux_data[3:5]
+    prior._reference_params = reference_params
+    prior._required_variables = required_variables
+    prior._condition_func = condition_func
+    return prior
+
+
+def dict_flatten(prior_dict: PriorDict):
+    prior_dict.convert_floats_to_delta_functions()
+    children = (
+        {k: v for k, v in prior_dict.items()},
+    )
+    aux_data = (
+        prior_dict.__class__,
+        prior_dict.conversion_function,
+        prior_dict._cached_normalizations,
+    )
+    return children, aux_data
+
+
+def dict_unflatten(aux_data, children) -> PriorDict:
+    cls, conversion_function, cached_normalizations = aux_data
+    prior_dict = cls.__new__(cls)
+    prior_dict.conversion_function = conversion_function
+    prior_dict._cached_normalizations = cached_normalizations
+    for k, v in children[0].items():
+        prior_dict[k] = v
+    return prior_dict
+
+
+def conditional_dict_flatten(prior_dict: ConditionalPriorDict):
+    children, aux_data = dict_flatten(prior_dict)
+
+    aux_data += (
+        prior_dict._conditional_keys,
+        prior_dict._unconditional_keys,
+        prior_dict._rescale_keys,
+        prior_dict._rescale_indexes,
+        prior_dict._least_recently_rescaled_keys,
+        prior_dict._resolved,
+    )
+
+    return children, aux_data
+
+
+def conditional_dict_unflatten(aux_data, children) -> ConditionalPriorDict:
+    prior_dict = dict_unflatten(aux_data[:3], children[:1])
+    (
+        conditional,
+        unconditional,
+        rescale,
+        indexes,
+        least_recently_rescaled,
+        resolved,
+    ) = aux_data[3:9]
+    prior_dict._conditional_keys = conditional
+    prior_dict._unconditional_keys = unconditional
+    prior_dict._rescale_keys = rescale
+    prior_dict._rescale_indexes = indexes
+    prior_dict._least_recently_rescaled_keys = least_recently_rescaled
+    prior_dict._resolved = resolved
+    return prior_dict
+
+
+def dirichlet_dict_flatten(prior_dict):
+    children, aux_data = conditional_dict_flatten(prior_dict)
+
+    aux_data += (prior_dict.n_dim, prior_dict.label)
+
+    return children, aux_data
+
+
+def dirichlet_dict_unflatten(aux_data, children):
+    prior_dict = conditional_dict_unflatten(aux_data[:8], children[:2])
+    n_dim, label = aux_data[8:10]
+    prior_dict.n_dim = n_dim
+    prior_dict.label = label
+    return prior_dict
+
+
+register_pytree_node(PriorDict, dict_flatten, dict_unflatten)
+register_pytree_node(ConditionalPriorDict, conditional_dict_flatten, conditional_dict_unflatten)
+register_pytree_node(DirichletPriorDict, dirichlet_dict_flatten, dirichlet_dict_unflatten)
+register_pytree_node(CBCPriorDict, conditional_dict_flatten, conditional_dict_unflatten)
+register_pytree_node(BBHPriorDict, conditional_dict_flatten, conditional_dict_unflatten)
+register_pytree_node(BNSPriorDict, conditional_dict_flatten, conditional_dict_unflatten)
+
+for cls in list(globals().values()):
+    if not isinstance(cls, type) or not issubclass(cls, Prior):
+        continue
+    elif hasattr(cls, "pytree_flatten"):
+        register_pytree_node(cls, cls.pytree_flatten, cls.pytree_unflatten)
+    elif cls in REGISTRY:
+        register_pytree_node(cls, *REGISTRY[cls])
+    elif hasattr(cls, "condition_func"):
+        register_pytree_node(cls, conditional_flatten, conditional_unflatten)
+    else:
+        register_pytree_node(cls, prior_flatten, prior_unflatten)

--- a/bilby/compat/pytrees/prior.py
+++ b/bilby/compat/pytrees/prior.py
@@ -1,3 +1,6 @@
+# flake8: noqa
+# global imports make pre-commits unhappy
+
 from jax.tree_util import register_pytree_node
 
 from ...core.prior.analytical import *
@@ -151,8 +154,6 @@ for cls in list(globals().values()):
         continue
     elif hasattr(cls, "pytree_flatten"):
         register_pytree_node(cls, cls.pytree_flatten, cls.pytree_unflatten)
-    elif cls in REGISTRY:
-        register_pytree_node(cls, *REGISTRY[cls])
     elif hasattr(cls, "condition_func"):
         register_pytree_node(cls, conditional_flatten, conditional_unflatten)
     else:

--- a/bilby/compat/pytrees/utils.py
+++ b/bilby/compat/pytrees/utils.py
@@ -1,0 +1,51 @@
+from interpax import Interpolator1D
+from jax.tree_util import register_pytree_node
+
+from ...core.series import CoupledTimeAndFrequencySeries
+from ...core.utils.calculus import WrappedInterp1d
+
+
+def interp1d_flatten(interp: WrappedInterp1d):
+    children = (interp.x, interp.y, interp.fill_value)
+    aux_data = (interp.kind,)
+    return children, aux_data
+
+
+def interp1d_unflatten(aux_data, children) -> Interpolator1D:
+    x, y, fill_value = children
+    kind = aux_data[0]
+    return Interpolator1D(x=x, f=y, method=kind, extrap=fill_value)
+
+
+def tfs_flatten(tfs: CoupledTimeAndFrequencySeries):
+    children = (
+        tfs.start_time,
+        tfs._time_array,
+        tfs._frequency_array,
+    )
+    aux_data = (
+        tfs._duration,
+        tfs._sampling_frequency,
+        tfs._frequency_array_updated,
+        tfs._time_array_updated,
+    )
+    return children, aux_data
+
+
+def tfs_unflatten(aux_data, children) -> CoupledTimeAndFrequencySeries:
+    tfs = CoupledTimeAndFrequencySeries.__new__(CoupledTimeAndFrequencySeries)
+
+    tfs._start_time = children[0]
+    tfs._time_array = children[1]
+    tfs._frequency_array = children[2]
+
+    tfs._duration = aux_data[0]
+    tfs._sampling_frequency = aux_data[1]
+    tfs._frequency_array_updated = aux_data[2]
+    tfs._time_array_updated = aux_data[3]
+
+    return tfs
+
+
+register_pytree_node(WrappedInterp1d, interp1d_flatten, interp1d_unflatten)
+register_pytree_node(CoupledTimeAndFrequencySeries, tfs_flatten, tfs_unflatten)

--- a/bilby/core/likelihood.py
+++ b/bilby/core/likelihood.py
@@ -276,7 +276,7 @@ class PoissonLikelihood(Analytical1DLikelihood):
     @property
     def y(self):
         """ Property assures that y-value is a positive integer. """
-        return self.__y
+        return self._y
 
     @y.setter
     def y(self, y):
@@ -287,7 +287,7 @@ class PoissonLikelihood(Analytical1DLikelihood):
         # torch doesn't support checking dtype kind
         if (not aac.is_torch_namespace(xp) and y.dtype.kind not in 'ui') or xp.any(y < 0):
             raise ValueError("Data must be non-negative integers")
-        self.__y = y
+        self._y = y
 
 
 class ExponentialLikelihood(Analytical1DLikelihood):

--- a/bilby/core/likelihood.py
+++ b/bilby/core/likelihood.py
@@ -262,13 +262,11 @@ class PoissonLikelihood(Analytical1DLikelihood):
                 "Poisson rate function returns wrong value type! "
                 "Is {} when it should be numpy.ndarray".format(type(rate)))
         xp = aac.get_namespace(rate)
-        if xp.any(rate < 0.):
+        if not aac.is_jax_namespace(xp) and xp.any(rate < 0.):
             raise ValueError(("Poisson rate function returns a negative",
                               " value!"))
-        elif xp.any(rate == 0.):
-            return -np.inf
-        else:
-            return xp.sum(-rate + self.y * xp.log(rate) - gammaln(self.y + 1))
+        rate = xp.maximum(rate, xp.asarray(0.0))
+        return xp.sum(-rate + self.y * xp.log(rate) - gammaln(self.y + 1))
 
     def __repr__(self):
         return Analytical1DLikelihood.__repr__(self)
@@ -312,9 +310,8 @@ class ExponentialLikelihood(Analytical1DLikelihood):
     def log_likelihood(self, parameters):
         mu = self.func(self.x, **self.model_parameters(parameters=parameters), **self.kwargs)
         xp = array_module(mu)
-        if xp.any(mu < 0.):
-            return -np.inf
-        return -xp.sum(xp.log(mu) + (self.y / mu))
+        val = xp.nan_to_num(xp.log(mu) + (self.y / mu), nan=np.inf, posinf=np.inf, neginf=-np.inf)
+        return -xp.sum(val)
 
     def __repr__(self):
         return Analytical1DLikelihood.__repr__(self)
@@ -376,10 +373,12 @@ class StudentTLikelihood(Analytical1DLikelihood):
                              "t-likelihood must be positive")
 
         xp = array_module(self.x)
-        log_l =\
-            xp.sum(- (nu + 1) * xp.log1p(self.lam * self.residual(parameters=parameters)**2 / nu) / 2 +
-                   xp.log(xp.asarray(self.lam / (nu * np.pi))) / 2 +
-                   gammaln((nu + 1) / 2) - gammaln(nu / 2))
+        log_l = xp.sum(xp.nan_to_num(
+            - (nu + 1) * xp.log1p(self.lam * self.residual(parameters=parameters)**2 / nu) / 2
+            + xp.log(xp.asarray(self.lam / (nu * np.pi))) / 2
+            + gammaln((nu + 1) / 2) - gammaln(nu / 2),
+            nan=np.inf, posinf=np.inf, neginf=-np.inf
+        ))
         return log_l
 
     def __repr__(self):

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -123,11 +123,13 @@ class PowerLaw(Prior):
         =======
         Union[float, array_like]: Rescaled probability
         """
-        if self.alpha == -1:
-            return self.minimum * xp.exp(val * xp.log(xp.asarray(self.maximum / self.minimum)))
-        else:
-            return (self.minimum ** (1 + self.alpha) + val *
-                    (self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha))) ** (1. / (1 + self.alpha))
+        with np.errstate(divide='ignore', invalid='ignore'):
+            return xp.where(
+                self.alpha != -1,
+                (self.minimum ** (1 + self.alpha) + val *
+                (self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha))) ** (1. / xp.asarray(1 + self.alpha)),
+                self.minimum * xp.exp(val * xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)))
+            )
 
     @xp_wrap
     def prob(self, val, *, xp=None):
@@ -141,14 +143,13 @@ class PowerLaw(Prior):
         =======
         float: Prior probability of val
         """
-        if self.alpha == -1:
-            return xp.nan_to_num(
-                1 / val / xp.log(xp.asarray(self.maximum / self.minimum))
-            ) * self.is_in_prior_range(val)
-        else:
-            return xp.nan_to_num(val ** self.alpha * (1 + self.alpha) /
-                                 (self.maximum ** (1 + self.alpha) -
-                                  self.minimum ** (1 + self.alpha))) * self.is_in_prior_range(val)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            norm = xp.where(
+                self.alpha != -1,
+                (1 + self.alpha) / (self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)),
+                1 / xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)),
+            )
+        return xp.nan_to_num(val ** self.alpha * norm) * self.is_in_prior_range(val)
 
     @xp_wrap
     def ln_prob(self, val, *, xp=None):
@@ -163,14 +164,13 @@ class PowerLaw(Prior):
         float:
 
         """
-        if self.alpha == -1:
-            normalising = 1. / xp.log(xp.asarray(self.maximum / self.minimum))
-        else:
-            normalising = (1 + self.alpha) / xp.asarray(
-                self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)
-            )
-
         with np.errstate(divide='ignore', invalid='ignore'):
+            normalising = xp.where(
+                self.alpha != -1,
+                (1 + self.alpha)
+                / xp.asarray(self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)),
+                1 / xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)),
+            )
             ln_in_range = xp.log(1. * self.is_in_prior_range(val))
             ln_p = self.alpha * xp.nan_to_num(xp.log(val)) + xp.log(normalising)
 
@@ -178,13 +178,13 @@ class PowerLaw(Prior):
 
     @xp_wrap
     def cdf(self, val, *, xp=None):
-        if self.alpha == -1:
-            with np.errstate(invalid="ignore"):
-                _cdf = xp.log(val / self.minimum) / xp.log(xp.asarray(self.maximum / self.minimum))
-        else:
-            _cdf = (
+        with np.errstate(divide='ignore', invalid='ignore'):
+            _cdf = xp.where(
+                self.alpha != -1,
                 (val ** (self.alpha + 1) - self.minimum ** (self.alpha + 1))
-                / (self.maximum ** (self.alpha + 1) - self.minimum ** (self.alpha + 1))
+                / (self.maximum ** (self.alpha + 1) - self.minimum ** (self.alpha + 1)),
+                xp.log(val / self.minimum)
+                / xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)),
             )
         _cdf = xp.clip(_cdf, 0, 1)
         return _cdf

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -262,8 +262,8 @@ class Uniform(Prior):
 
     @xp_wrap
     def cdf(self, val, *, xp=None):
-        _cdf = (val - self.minimum) / (self.maximum - self.minimum)
-        return xp.clip(_cdf, 0, 1)
+        _cdf = xp.asarray((val - self.minimum) / (self.maximum - self.minimum))
+        return xp.clip(_cdf, xp.asarray(0), xp.asarray(1))
 
 
 class LogUniform(PowerLaw):

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -1618,7 +1618,7 @@ class WeightedDiscreteValues(Prior):
         # turn 0d array to scalar
         return lnp[()]
 
-   @property
+    @property
     def weights(self):
         return self._weights_array.tolist()
 
@@ -1654,7 +1654,7 @@ class WeightedDiscreteValues(Prior):
         prior._weights_array = weights
         prior._lnweights_array = ln_weights
         prior._cumulative_weights_array = cumulative_weights
-        prior._minimum= minimum
+        prior._minimum = minimum
         prior._maximum = maximum
         return prior
 

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -125,9 +125,11 @@ class PowerLaw(Prior):
         """
         with np.errstate(divide='ignore', invalid='ignore'):
             return xp.where(
-                self.alpha != -1,
-                (self.minimum ** (1 + self.alpha) + val *
-                (self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha))) ** (1. / xp.asarray(1 + self.alpha)),
+                xp.asarray(self.alpha != -1),
+                (
+                    self.minimum ** (1 + self.alpha)
+                    + val * (self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha))
+                ) ** (1. / xp.asarray(1 + self.alpha)),
                 self.minimum * xp.exp(val * xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)))
             )
 
@@ -145,7 +147,7 @@ class PowerLaw(Prior):
         """
         with np.errstate(divide='ignore', invalid='ignore'):
             norm = xp.where(
-                self.alpha != -1,
+                xp.asarray(self.alpha != -1),
                 (1 + self.alpha) / xp.asarray(self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)),
                 1 / xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)),
             )
@@ -166,7 +168,7 @@ class PowerLaw(Prior):
         """
         with np.errstate(divide='ignore', invalid='ignore'):
             normalising = xp.where(
-                self.alpha != -1,
+                xp.asarray(self.alpha != -1),
                 (1 + self.alpha)
                 / xp.asarray(self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)),
                 1 / xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)),
@@ -180,7 +182,7 @@ class PowerLaw(Prior):
     def cdf(self, val, *, xp=None):
         with np.errstate(divide='ignore', invalid='ignore'):
             _cdf = xp.where(
-                self.alpha != -1,
+                xp.asarray(self.alpha != -1),
                 (val ** (self.alpha + 1) - self.minimum ** (self.alpha + 1))
                 / (self.maximum ** (self.alpha + 1) - self.minimum ** (self.alpha + 1)),
                 xp.log(val / self.minimum)

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -1531,7 +1531,6 @@ class WeightedDiscreteValues(Prior):
                 + f"while number of values is {self.values}"
             )
         self._weights_array = weights[sorter]
-        self.weights = self._weights_array.tolist()
         self._lnweights_array = xp.log(self._weights_array)
 
         # save cdf for rescaling

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -21,6 +21,8 @@ from ...compat.utils import array_module, xp_wrap
 
 class DeltaFunction(Prior):
 
+    _leaves = ["peak", "_minimum", "_maximum", "least_recently_sampled"]
+
     def __init__(self, peak, name=None, latex_label=None, unit=None):
         """Dirac delta function prior, this always returns peak.
 
@@ -76,6 +78,8 @@ class DeltaFunction(Prior):
 
 
 class PowerLaw(Prior):
+
+    _leaves = ["alpha"]
 
     def __init__(self, alpha, minimum, maximum, name=None, latex_label=None,
                  unit=None, boundary=None):
@@ -509,6 +513,8 @@ class Sine(Prior):
 
 class Gaussian(Prior):
 
+    _leaves = ["mu", "sigma"]
+
     def __init__(self, mu, sigma, name=None, latex_label=None, unit=None, boundary=None):
         """Gaussian prior with mean mu and width sigma
 
@@ -581,6 +587,8 @@ class Normal(Gaussian):
 
 
 class TruncatedGaussian(Prior):
+
+    _leaves = ["mu", "sigma"]
 
     def __init__(self, mu, sigma, minimum, maximum, name=None,
                  latex_label=None, unit=None, boundary=None):
@@ -662,6 +670,9 @@ class TruncatedNormal(TruncatedGaussian):
 
 
 class HalfGaussian(TruncatedGaussian):
+
+    _leaves = ["sigma", "mu"]
+
     def __init__(self, sigma, name=None, latex_label=None, unit=None, boundary=None):
         """A Gaussian with its mode at zero, and truncated to only be positive.
 
@@ -688,6 +699,9 @@ class HalfNormal(HalfGaussian):
 
 
 class LogNormal(Prior):
+
+    _leaves = ["mu", "sigma"]
+
     def __init__(self, mu, sigma, name=None, latex_label=None, unit=None, boundary=None):
         """Log-normal prior with mean mu and width sigma
 
@@ -771,6 +785,9 @@ class LogGaussian(LogNormal):
 
 
 class Exponential(Prior):
+
+    _leaves = ["mu"]
+
     def __init__(self, mu, name=None, latex_label=None, unit=None, boundary=None):
         """Exponential prior with mean mu
 
@@ -837,6 +854,9 @@ class Exponential(Prior):
 
 
 class StudentT(Prior):
+
+    _leaves = ["df", "mu", "scale"]
+
     def __init__(self, df, mu=0., scale=1., name=None, latex_label=None,
                  unit=None, boundary=None):
         """Student's t-distribution prior with number of degrees of freedom df,
@@ -925,6 +945,9 @@ class StudentT(Prior):
 
 
 class Beta(Prior):
+
+    _leaves = ["alpha", "beta"]
+
     def __init__(self, alpha, beta, minimum=0, maximum=1, name=None,
                  latex_label=None, unit=None, boundary=None):
         """Beta distribution
@@ -1030,6 +1053,9 @@ class Beta(Prior):
 
 
 class Logistic(Prior):
+
+    _leaves = ["mu", "scale"]
+
     def __init__(self, mu, scale, name=None, latex_label=None, unit=None, boundary=None):
         """Logistic distribution
 
@@ -1105,6 +1131,9 @@ class Logistic(Prior):
 
 
 class Cauchy(Prior):
+
+    _leaves = ["alpha", "beta"]
+
     def __init__(self, alpha, beta, name=None, latex_label=None, unit=None, boundary=None):
         """Cauchy distribution
 
@@ -1181,6 +1210,9 @@ class Lorentzian(Cauchy):
 
 
 class Gamma(Prior):
+
+    _leaves = ["k", "theta"]
+
     def __init__(self, k, theta=1., name=None, latex_label=None, unit=None, boundary=None):
         """Gamma distribution
 
@@ -1264,6 +1296,9 @@ class Gamma(Prior):
 
 
 class ChiSquared(Gamma):
+
+    _leaves = ["nu", "theta"]
+
     def __init__(self, nu, name=None, latex_label=None, unit=None, boundary=None):
         """Chi-squared distribution
 
@@ -1299,6 +1334,9 @@ class ChiSquared(Gamma):
 
 
 class FermiDirac(Prior):
+
+    _leaves = ["sigma", "mu", "r", "expr"]
+
     def __init__(self, sigma, mu=None, r=None, name=None, latex_label=None,
                  unit=None):
         """A Fermi-Dirac type prior, with a fixed lower boundary at zero
@@ -1580,6 +1618,46 @@ class WeightedDiscreteValues(Prior):
         # turn 0d array to scalar
         return lnp[()]
 
+   @property
+    def weights(self):
+        return self._weights_array.tolist()
+
+    def pytree_flatten(self):
+        children = (
+            self._values_array,
+            self._weights_array,
+            self._lnweights_array,
+            self._cumulative_weights_array,
+            self.minimum,
+            self.maximum,
+        )
+        aux_data = (
+            self.name,
+            self.latex_label,
+            self.unit,
+            self.boundary,
+            self.nvalues,
+        )
+        return children, aux_data
+
+    @classmethod
+    def pytree_unflatten(cls, aux_data, children):
+        prior = cls.__new__(cls)
+        name, latex_label, unit, boundary, nvalues = aux_data
+        values, weights, ln_weights, cumulative_weights, minimum, maximum = children
+        prior.name = name
+        prior.latex_label = latex_label
+        prior.unit = unit
+        prior.boundary = boundary
+        prior.nvalues = nvalues
+        prior._values_array = values
+        prior._weights_array = weights
+        prior._lnweights_array = ln_weights
+        prior._cumulative_weights_array = cumulative_weights
+        prior._minimum= minimum
+        prior._maximum = maximum
+        return prior
+
 
 class DiscreteValues(WeightedDiscreteValues):
     def __init__(self, values, name=None, latex_label=None,
@@ -1646,6 +1724,17 @@ class WeightedCategorical(WeightedDiscreteValues):
             boundary=boundary,
         )
 
+    def pytree_flatten(self):
+        children, aux_data = super().pytree_flatten()
+        aux_data += (self.ncategories,)
+        return children, aux_data
+
+    @classmethod
+    def pytree_unflatten(cls, aux_data, children):
+        prior = super().pytree_unflatten(aux_data[:-1], children)
+        prior.ncategories = aux_data[-1]
+        return prior
+
 
 class Categorical(DiscreteValues):
     def __init__(
@@ -1685,6 +1774,15 @@ class Triangular(Prior):
     where the mode has the highest pdf value.
 
     """
+
+    _leaves = [
+        "mode",
+        "fractional_mode",
+        "scale",
+        "rescaled_minimum",
+        "rescaled_maximum",
+    ]
+
     def __init__(self, mode, minimum, maximum, name=None, latex_label=None, unit=None):
         super(Triangular, self).__init__(
             name=name,

--- a/bilby/core/prior/analytical.py
+++ b/bilby/core/prior/analytical.py
@@ -146,7 +146,7 @@ class PowerLaw(Prior):
         with np.errstate(divide='ignore', invalid='ignore'):
             norm = xp.where(
                 self.alpha != -1,
-                (1 + self.alpha) / (self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)),
+                (1 + self.alpha) / xp.asarray(self.maximum ** (1 + self.alpha) - self.minimum ** (1 + self.alpha)),
                 1 / xp.log(xp.asarray(self.maximum) / xp.asarray(self.minimum)),
             )
         return xp.nan_to_num(val ** self.alpha * norm) * self.is_in_prior_range(val)

--- a/bilby/core/prior/base.py
+++ b/bilby/core/prior/base.py
@@ -21,6 +21,7 @@ from ...compat.utils import xp_wrap
 
 class Prior(object):
     _default_latex_labels = {}
+    _leaves = []
 
     def __init__(self, name=None, latex_label=None, unit=None, minimum=-np.inf,
                  maximum=np.inf, check_range_nonzero=True, boundary=None):
@@ -493,6 +494,8 @@ class Prior(object):
 
 
 class Constraint(Prior):
+
+    _leaves = ["_minimum", "_maximum"]
 
     def __init__(self, minimum, maximum, name=None, latex_label=None,
                  unit=None):

--- a/bilby/core/prior/base.py
+++ b/bilby/core/prior/base.py
@@ -21,6 +21,7 @@ from ...compat.utils import xp_wrap
 
 class Prior(object):
     _default_latex_labels = {}
+    _leaves = []
 
     def __init__(self, name=None, latex_label=None, unit=None, minimum=-np.inf,
                  maximum=np.inf, check_range_nonzero=True, boundary=None):
@@ -505,6 +506,8 @@ class Prior(object):
 
 
 class Constraint(Prior):
+
+    _leaves = ["_minimum", "_maximum"]
 
     def __init__(self, minimum, maximum, name=None, latex_label=None,
                  unit=None):

--- a/bilby/core/prior/conditional.py
+++ b/bilby/core/prior/conditional.py
@@ -11,6 +11,12 @@ from ...compat.utils import xp_wrap
 
 def conditional_prior_factory(prior_class):
     class ConditionalPrior(prior_class):
+
+        _leaves = prior_class._leaves
+
+        __name__ = 'Conditional{}'.format(prior_class.__name__)
+        __qualname__ = 'Conditional{}'.format(prior_class.__qualname__)
+
         def __init__(self, condition_func, name=None, latex_label=None, unit=None,
                      boundary=None, **reference_params):
             """
@@ -59,8 +65,6 @@ def conditional_prior_factory(prior_class):
             self._required_variables = None
             self.condition_func = condition_func
             self._reference_params = reference_params
-            self.__class__.__name__ = 'Conditional{}'.format(prior_class.__name__)
-            self.__class__.__qualname__ = 'Conditional{}'.format(prior_class.__qualname__)
 
         def sample(self, size=None, *, random_state=None, **required_variables):
             """Draw a sample from the prior
@@ -381,6 +385,8 @@ class DirichletElement(ConditionalBeta):
         This should be the same for all elements.
     """
 
+    _leaves = []
+
     def __init__(self, order, n_dimensions, label):
         """ """
         super(DirichletElement, self).__init__(
@@ -408,6 +414,16 @@ class DirichletElement(ConditionalBeta):
 
     def get_instantiation_dict(self):
         return Prior.get_instantiation_dict(self)
+
+    def pytree_flatten(self):
+        children = ()
+        aux_data = (self.order, self.n_dimensions, self.label)
+        return children, aux_data
+
+    @classmethod
+    def pytree_unflatten(cls, aux_data, children):
+        print(aux_data, children)
+        return cls(*aux_data)
 
 
 class ConditionalPriorException(PriorException):

--- a/bilby/core/prior/interpolated.py
+++ b/bilby/core/prior/interpolated.py
@@ -1,3 +1,5 @@
+import array_api_compat as aac
+import array_api_extra as xpx
 import numpy as np
 from scipy.integrate import trapezoid
 
@@ -8,6 +10,20 @@ from ...compat.utils import xp_wrap
 
 
 class Interped(Prior):
+
+    _leaves = [
+        "xx",
+        "_yy",
+        "YY",
+        "_minimum",
+        "_maximum",
+        "min_limit",
+        "max_limit",
+        "probability_density",
+        "cumulative_distribution",
+        "inverse_cumulative_distribution",
+        "_all_interpolated",
+    ]
 
     def __init__(self, xx, yy, minimum=np.nan, maximum=np.nan, name=None,
                  latex_label=None, unit=None, boundary=None):
@@ -52,7 +68,7 @@ class Interped(Prior):
         self.probability_density = None
         self.cumulative_distribution = None
         self.inverse_cumulative_distribution = None
-        self.__all_interpolated = interp1d(x=xx, y=yy, bounds_error=False, fill_value=0)
+        self._all_interpolated = interp1d(x=xx, y=yy, bounds_error=False, fill_value=0)
         minimum = float(np.nanmax(np.array((min(xx), minimum))))
         maximum = float(np.nanmin(np.array((max(xx), maximum))))
         super(Interped, self).__init__(name=name, latex_label=latex_label, unit=unit,
@@ -155,12 +171,13 @@ class Interped(Prior):
     @yy.setter
     def yy(self, yy):
         self._yy = yy
-        self.__all_interpolated = interp1d(x=self.xx, y=self._yy, bounds_error=False, fill_value=0)
+        self._all_interpolated = interp1d(x=self.xx, y=self._yy, bounds_error=False, fill_value=0)
         self._update_instance()
 
     def _update_instance(self):
-        self.xx = np.linspace(self.minimum, self.maximum, len(self.xx))
-        self._yy = self.__all_interpolated(self.xx)
+        xp = aac.array_namespace(self.xx)
+        self.xx = xp.linspace(self.minimum, self.maximum, len(self.xx))
+        self._yy = self._all_interpolated(self.xx)
         self._initialize_attributes()
 
     def _initialize_attributes(self):
@@ -170,13 +187,15 @@ class Interped(Prior):
         self._yy /= trapezoid(self._yy, self.xx)
         self.YY = cumulative_trapezoid(self._yy, self.xx, initial=0)
         # Need last element of cumulative distribution to be exactly one.
-        self.YY[-1] = 1
+        self.YY = xpx.at(self.YY, -1).set(1)
         self.probability_density = interp1d(x=self.xx, y=self._yy, bounds_error=False, fill_value=0)
         self.cumulative_distribution = interp1d(x=self.xx, y=self.YY, bounds_error=False, fill_value=(0, 1))
         self.inverse_cumulative_distribution = interp1d(x=self.YY, y=self.xx, bounds_error=True)
 
 
 class FromFile(Interped):
+
+    _leaves = Interped._leaves + ["file_name"]
 
     def __init__(self, file_name, minimum=None, maximum=None, name=None,
                  latex_label=None, unit=None, boundary=None):
@@ -210,3 +229,13 @@ class FromFile(Interped):
             logger.warning("Can't load {}.".format(self.file_name))
             logger.warning("Format should be:")
             logger.warning(r"x\tp(x)")
+
+    def pytree_flatten(self):
+        children, aux_data = super().pytree_flatten()
+        aux_data += (self.file_name,)
+        return children, aux_data
+
+    def pytree_unflatten(self, aux_data, children):
+        prior = super().pytree_unflatten(aux_data[:-1], children)
+        prior.filename = aux_data[-1]
+        return prior

--- a/bilby/core/prior/slabspike.py
+++ b/bilby/core/prior/slabspike.py
@@ -7,6 +7,8 @@ from ...compat.utils import xp_wrap
 
 class SlabSpikePrior(Prior):
 
+    _leaves = ["slab", "_spike_location", "_spike_height", "inverse_cdf_below_spike", "_minimum", "_maximum"]
+
     def __init__(self, slab, spike_location=None, spike_height=0):
         """'Slab-and-spike' prior, see e.g. https://arxiv.org/abs/1812.07259
         This prior is composed of a `slab`, i.e. any common prior distribution,
@@ -43,7 +45,7 @@ class SlabSpikePrior(Prior):
 
     @property
     def spike_location(self):
-        return self._spike_loc
+        return self._spike_location
 
     @spike_location.setter
     def spike_location(self, spike_loc):
@@ -51,7 +53,7 @@ class SlabSpikePrior(Prior):
             spike_loc = self.minimum
         if not self.minimum <= spike_loc <= self.maximum:
             raise ValueError("Spike location {} not within prior domain ".format(spike_loc))
-        self._spike_loc = spike_loc
+        self._spike_location = spike_loc
 
     @property
     def spike_height(self):

--- a/bilby/core/series.py
+++ b/bilby/core/series.py
@@ -1,7 +1,7 @@
 from . import utils
 
 
-class CoupledTimeAndFrequencySeries(object):
+class CoupledTimeAndFrequencySeries:
 
     def __init__(self, duration=None, sampling_frequency=None, start_time=0):
         """ A waveform generator
@@ -36,7 +36,7 @@ class CoupledTimeAndFrequencySeries(object):
         array_like: The frequency array
         """
         if not self._frequency_array_updated:
-            if self.sampling_frequency and self.duration:
+            if self.sampling_frequency is not None and self.duration is not None:
                 self._frequency_array = utils.create_frequency_series(
                     sampling_frequency=self.sampling_frequency,
                     duration=self.duration)

--- a/bilby/core/utils/calculus.py
+++ b/bilby/core/utils/calculus.py
@@ -190,11 +190,8 @@ def logtrapzexp(lnf, dx, *, xp=np):
     return logsumexp(xp.asarray([logsumexp(lnfdx1), logsumexp(lnfdx2)])) - np.log(2)
 
 
-def interp1d(x, y, kind=None, axis=-1, bounds_error=None, fill_value=np.nan):
+def interp1d(x, y, kind="linear", axis=-1, bounds_error=None, fill_value=np.nan):
     if not BILBY_ARRAY_API:
-        if kind is None:
-            kind = "linear"
-
         return WrappedInterp1d(
             x=x,
             y=y,
@@ -205,8 +202,6 @@ def interp1d(x, y, kind=None, axis=-1, bounds_error=None, fill_value=np.nan):
         )
 
     if aac.is_jax_array(x):
-        if kind is None:
-            kind = "cubic"
         from interpax import Interpolator1D
 
         return Interpolator1D(
@@ -216,8 +211,6 @@ def interp1d(x, y, kind=None, axis=-1, bounds_error=None, fill_value=np.nan):
             extrap=fill_value,
         )
     else:
-        if kind is None:
-            kind = "linear"
         return WrappedInterp1d(
             x=x,
             y=y,
@@ -302,7 +295,7 @@ class WrappedInterp1d(_interp1d):
         # some backends, e.g., torch don't support interpolation, add an explicit
         # cast to make it not crash
         output = super().__call__(x)
-        xp = aac.array_namespace(x)
+        xp = array_module(x)
         return xp.asarray(output)
 
     def __eq__(self, other):

--- a/bilby/core/utils/calculus.py
+++ b/bilby/core/utils/calculus.py
@@ -299,8 +299,11 @@ class WrappedInterp1d(_interp1d):
         self.kind = kind
 
     def __call__(self, x):
+        # some backends, e.g., torch don't support interpolation, add an explicit
+        # cast to make it not crash
         output = super().__call__(x)
-        return output
+        xp = aac.array_namespace(x)
+        return xp.asarray(output)
 
     def __eq__(self, other):
         for key in self.__dict__:

--- a/bilby/core/utils/calculus.py
+++ b/bilby/core/utils/calculus.py
@@ -300,8 +300,6 @@ class WrappedInterp1d(_interp1d):
 
     def __call__(self, x):
         output = super().__call__(x)
-        if isinstance(x, (float, int)):
-            output = output.item()
         return output
 
     def __eq__(self, other):

--- a/bilby/core/utils/calculus.py
+++ b/bilby/core/utils/calculus.py
@@ -190,32 +190,42 @@ def logtrapzexp(lnf, dx, *, xp=np):
     return logsumexp(xp.asarray([logsumexp(lnfdx1), logsumexp(lnfdx2)])) - np.log(2)
 
 
-class interp1d(_interp1d):
+def interp1d(x, y, kind=None, axis=-1, bounds_error=None, fill_value=np.nan):
+    if not BILBY_ARRAY_API:
+        if kind is None:
+            kind = "linear"
 
-    def __call__(self, x):
-        if not BILBY_ARRAY_API:
-            return super().__call__(x)
+        return WrappedInterp1d(
+            x=x,
+            y=y,
+            kind=kind,
+            axis=axis,
+            bounds_error=bounds_error,
+            fill_value=fill_value,
+        )
 
-        import array_api_compat as aac
+    if aac.is_jax_array(x):
+        if kind is None:
+            kind = "cubic"
+        from interpax import Interpolator1D
 
-        xp = array_module(x)
-        if aac.is_numpy_namespace(xp):
-            return super().__call__(x)
-        else:
-            from ...compat.patches import interp
-
-            if isinstance(self.fill_value, tuple):
-                left, right = self.fill_value
-            else:
-                left = right = self.fill_value
-
-            return interp(
-                x,
-                xp.asarray(self.x),
-                xp.asarray(self.y),
-                left=left,
-                right=right,
-            )
+        return Interpolator1D(
+            x=x,
+            f=y,
+            method=kind,
+            extrap=fill_value,
+        )
+    else:
+        if kind is None:
+            kind = "linear"
+        return WrappedInterp1d(
+            x=x,
+            y=y,
+            kind=kind,
+            axis=axis,
+            bounds_error=bounds_error,
+            fill_value=fill_value,
+        )
 
 
 class BoundedRectBivariateSpline(RectBivariateSpline):
@@ -276,11 +286,18 @@ class BoundedRectBivariateSpline(RectBivariateSpline):
         )
 
 
-class WrappedInterp1d(interp1d):
+class WrappedInterp1d(_interp1d):
     """
     A wrapper around scipy interp1d which sets equality-by-instantiation and
     makes sure that the output is a float if the input is a float or int.
     """
+
+    def __init__(self, x, y, kind="linear", axis=-1, bounds_error=False, fill_value=np.nan):
+        super().__init__(
+            x=x, y=y, kind=kind, axis=axis, bounds_error=bounds_error, fill_value=fill_value
+        )
+        self.kind = kind
+
     def __call__(self, x):
         output = super().__call__(x)
         if isinstance(x, (float, int)):

--- a/bilby/gw/compat/jax.py
+++ b/bilby/gw/compat/jax.py
@@ -6,6 +6,7 @@ from ..time import (
     LEAP_SECONDS as _LEAP_SECONDS,
     n_leap_seconds as _n_leap_seconds,
 )
+from . import pytrees  # noqa
 
 __all__ = ["n_leap_seconds"]
 

--- a/bilby/gw/compat/pytrees.py
+++ b/bilby/gw/compat/pytrees.py
@@ -78,7 +78,6 @@ def interferometer_flatten(ifo: Interferometer):
         ifo.geometry,
         ifo.calibration_model,
         ifo.reference_time,
-        getattr(ifo, "_reference_gmst", None),
     )
     aux_data = (
         ifo.name,
@@ -93,41 +92,38 @@ def interferometer_unflatten(aux_data, flat) -> Interferometer:
     ifo.power_spectral_density = flat[1]
     ifo.geometry = flat[2]
     ifo.calibration_model = flat[3]
-    ifo._reference_time = flat[4]
-    ifo._reference_gmst = flat[5]
+    ifo.reference_time = flat[4]
     ifo.meta_data = dict(name=ifo.name)
     return ifo
 
 
 def strain_data_flatten(strain_data: InterferometerStrainData):
     children = (
-        strain_data._frequency_mask,
-        # None,
         strain_data._minimum_frequency,
         strain_data._maximum_frequency,
         strain_data._frequency_domain_strain,
         strain_data._time_domain_strain,
         strain_data._times_and_frequencies,
         strain_data.notch_list,
+        strain_data.frequency_mask,
     )
-    aux_data = (
-        # strain_data.frequency_mask,
-    )
+    aux_data = ()
     return children, aux_data
 
 
 def strain_data_unflatten(aux_data, children) -> InterferometerStrainData:
     strain_data = InterferometerStrainData.__new__(InterferometerStrainData)
 
-    strain_data.notch_list = children[6]
+    strain_data.notch_list = children[5]
 
-    strain_data._frequency_mask = children[0]
+    strain_data._frequency_mask = children[6]
     strain_data._frequency_mask_updated = True
-    strain_data._minimum_frequency = children[1]
-    strain_data._maximum_frequency = children[2]
-    strain_data._frequency_domain_strain = children[3]
-    strain_data._time_domain_strain = children[4]
-    strain_data._times_and_frequencies = children[5]
+
+    strain_data._minimum_frequency = children[0]
+    strain_data._maximum_frequency = children[1]
+    strain_data._frequency_domain_strain = children[2]
+    strain_data._time_domain_strain = children[3]
+    strain_data._times_and_frequencies = children[4]
 
     return strain_data
 
@@ -228,9 +224,9 @@ def notch_list_unflatten(aux_data, children) -> NotchList:
 
 def wfg_flatten(wfg: WaveformGenerator):
     children = (
+        wfg._times_and_frequencies,
     )
     aux_data = (
-        wfg._times_and_frequencies,
         wfg.frequency_domain_source_model,
         wfg.time_domain_source_model,
         wfg.source_parameter_keys,
@@ -244,14 +240,14 @@ def wfg_flatten(wfg: WaveformGenerator):
 
 def wfg_unflatten(aux_data, children) -> WaveformGenerator:
     wfg = WaveformGenerator.__new__(WaveformGenerator)
-    wfg._times_and_frequencies = aux_data[0]
-    wfg.frequency_domain_source_model = aux_data[1]
-    wfg.time_domain_source_model = aux_data[2]
-    wfg.source_parameter_keys = aux_data[3]
-    wfg.parameter_conversion = aux_data[4]
-    wfg.use_cache = aux_data[5]
-    wfg._cache = aux_data[6]
-    wfg.waveform_arguments = aux_data[7]
+    wfg._times_and_frequencies = children[0]
+    wfg.frequency_domain_source_model = aux_data[0]
+    wfg.time_domain_source_model = aux_data[1]
+    wfg.source_parameter_keys = aux_data[2]
+    wfg.parameter_conversion = aux_data[3]
+    wfg.use_cache = aux_data[4]
+    wfg._cache = aux_data[5]
+    wfg.waveform_arguments = aux_data[6]
     return wfg
 
 

--- a/bilby/gw/compat/pytrees.py
+++ b/bilby/gw/compat/pytrees.py
@@ -61,8 +61,6 @@ def likelihood_unflatten(aux_data, flat) -> GravitationalWaveTransient:
     return likelihood
 
 
-
-
 def interferometer_list_flatten(ifos: InterferometerList):
     return tuple(ifos), None
 

--- a/bilby/gw/compat/pytrees.py
+++ b/bilby/gw/compat/pytrees.py
@@ -1,0 +1,271 @@
+from jax.tree_util import register_pytree_node
+
+from bilby.gw.likelihood.base import GravitationalWaveTransient
+from bilby.gw.detector.calibration import Recalibrate
+from bilby.gw.detector.geometry import InterferometerGeometry
+from bilby.gw.detector.interferometer import Interferometer
+from bilby.gw.detector.networks import InterferometerList
+from bilby.gw.detector.psd import PowerSpectralDensity
+from bilby.gw.detector.strain_data import InterferometerStrainData, NotchList
+from bilby.gw.waveform_generator import WaveformGenerator
+
+
+def likelihood_flatten(likelihood: GravitationalWaveTransient):
+    children = (
+        likelihood.interferometers,
+        likelihood.waveform_generator,
+        getattr(likelihood, "_times", None),
+        getattr(likelihood, "time_prior_array", None),
+        getattr(likelihood, "_delta_tc", None),
+        likelihood._noise_log_likelihood_value,
+        likelihood.reference_frame,
+        likelihood.reference_ifo,
+    )
+    aux_data = (
+        likelihood.time_marginalization,
+        likelihood.distance_marginalization,
+        likelihood.phase_marginalization,
+        likelihood.calibration_marginalization,
+        likelihood.jitter_time,
+        getattr(likelihood, "number_of_response_curves", 1000),
+        getattr(likelihood, "starting_index", 0),
+        likelihood.time_reference,
+        likelihood.marginalized_parameters,
+        likelihood.priors,
+    )
+    return children, aux_data
+
+
+def likelihood_unflatten(aux_data, flat) -> GravitationalWaveTransient:
+    likelihood = GravitationalWaveTransient.__new__(GravitationalWaveTransient)
+
+    likelihood._interferometers = flat[0]
+    likelihood.waveform_generator = flat[1]
+    likelihood._times = flat[2]
+    likelihood.time_prior_array = flat[3]
+    likelihood._delta_tc = flat[4]
+    likelihood._noise_log_likelihood_value = flat[5]
+    likelihood._reference_frame = flat[6]
+    likelihood.reference_ifo = flat[7]
+
+    likelihood.time_marginalization = aux_data[0]
+    likelihood.distance_marginalization = aux_data[1]
+    likelihood.phase_marginalization = aux_data[2]
+    likelihood.calibration_marginalization = aux_data[3]
+    likelihood.jitter_time = aux_data[4]
+    likelihood.number_of_response_curves = aux_data[5]
+    likelihood.starting_index = aux_data[6]
+    likelihood.time_reference = aux_data[7]
+    likelihood._marginalized_parameters = aux_data[8]
+    likelihood._prior = aux_data[9]
+    return likelihood
+
+
+
+
+def interferometer_list_flatten(ifos: InterferometerList):
+    return tuple(ifos), None
+
+
+def interferometer_list_unflatten(aux_data, flat) -> InterferometerList:
+    ifos = InterferometerList.__new__(InterferometerList)
+    list.extend(ifos, flat)
+    return ifos
+
+
+def interferometer_flatten(ifo: Interferometer):
+    children = (
+        ifo.strain_data,
+        ifo.power_spectral_density,
+        ifo.geometry,
+        ifo.calibration_model,
+        ifo.reference_time,
+        getattr(ifo, "_reference_gmst", None),
+    )
+    aux_data = (
+        ifo.name,
+    )
+    return children, aux_data
+
+
+def interferometer_unflatten(aux_data, flat) -> Interferometer:
+    ifo = Interferometer.__new__(Interferometer)
+    ifo.name = aux_data[0]
+    ifo.strain_data = flat[0]
+    ifo.power_spectral_density = flat[1]
+    ifo.geometry = flat[2]
+    ifo.calibration_model = flat[3]
+    ifo._reference_time = flat[4]
+    ifo._reference_gmst = flat[5]
+    ifo.meta_data = dict(name=ifo.name)
+    return ifo
+
+
+def strain_data_flatten(strain_data: InterferometerStrainData):
+    children = (
+        strain_data._frequency_mask,
+        # None,
+        strain_data._minimum_frequency,
+        strain_data._maximum_frequency,
+        strain_data._frequency_domain_strain,
+        strain_data._time_domain_strain,
+        strain_data._times_and_frequencies,
+        strain_data.notch_list,
+    )
+    aux_data = (
+        # strain_data.frequency_mask,
+    )
+    return children, aux_data
+
+
+def strain_data_unflatten(aux_data, children) -> InterferometerStrainData:
+    strain_data = InterferometerStrainData.__new__(InterferometerStrainData)
+
+    strain_data.notch_list = children[6]
+
+    strain_data._frequency_mask = children[0]
+    strain_data._frequency_mask_updated = True
+    strain_data._minimum_frequency = children[1]
+    strain_data._maximum_frequency = children[2]
+    strain_data._frequency_domain_strain = children[3]
+    strain_data._time_domain_strain = children[4]
+    strain_data._times_and_frequencies = children[5]
+
+    return strain_data
+
+
+def psd_flatten(psd: PowerSpectralDensity):
+    children = (
+        psd._cache,
+        psd._asd_array,
+        psd._psd_array,
+        psd.frequency_array,
+    )
+    aux_data = (
+        psd._asd_file,
+        psd._psd_file,
+    )
+    return children, aux_data
+
+
+def psd_unflatten(aux_data, children) -> PowerSpectralDensity:
+    import jax.numpy as jnp
+    psd = PowerSpectralDensity.__new__(PowerSpectralDensity)
+
+    psd._cache = children[0]
+    psd._asd_array = children[1]
+    psd._psd_array = children[2]
+    psd.frequency_array = children[3]
+
+    psd._asd_file = aux_data[0]
+    psd._psd_file = aux_data[1]
+
+    if isinstance(psd.frequency_array, jnp.ndarray):
+        psd._interpolate_power_spectral_density()
+
+    return psd
+
+
+def geometry_flatten(geometry: InterferometerGeometry):
+    children = (
+        geometry._latitude,
+        geometry._longitude,
+        geometry._elevation,
+        geometry._xarm_azimuth,
+        geometry._yarm_azimuth,
+        geometry._xarm_tilt,
+        geometry._yarm_tilt,
+        geometry._vertex,
+        geometry._x,
+        geometry._y,
+        geometry._detector_tensor,
+    )
+    aux_data = (
+        geometry.length,
+    )
+    return children, aux_data
+
+
+def geometry_unflatten(aux_data, children):
+    geometry = InterferometerGeometry.__new__(InterferometerGeometry)
+    geometry.length = aux_data[0]
+    geometry._latitude = children[0]
+    geometry._longitude = children[1]
+    geometry._elevation = children[2]
+    geometry._xarm_azimuth = children[3]
+    geometry._yarm_azimuth = children[4]
+    geometry._xarm_tilt = children[5]
+    geometry._yarm_tilt = children[6]
+    geometry._vertex = children[7]
+    geometry._x = children[8]
+    geometry._y = children[9]
+    geometry._detector_tensor = children[10]
+    geometry._detector_tensor_updated = True
+    geometry._vertex_updated = True
+    geometry._x_updated = True
+    geometry._y_updated = True
+    return geometry
+
+
+def recalibrate_flatten(recalib: Recalibrate):
+    children = (recalib.params,)
+    aux_data = (recalib.prefix,)
+    return children, aux_data
+
+
+def recalibrate_unflatten(aux_data, children) -> Recalibrate:
+    recalib = Recalibrate.__new__(Recalibrate)
+    recalib.prefix = aux_data[0]
+    recalib.params = children[0]
+    return recalib
+
+
+def notch_list_flatten(notches: NotchList):
+    return (), (notches,)
+
+
+def notch_list_unflatten(aux_data, children) -> NotchList:
+    return aux_data[0]
+
+
+def wfg_flatten(wfg: WaveformGenerator):
+    children = (
+    )
+    aux_data = (
+        wfg._times_and_frequencies,
+        wfg.frequency_domain_source_model,
+        wfg.time_domain_source_model,
+        wfg.source_parameter_keys,
+        wfg.parameter_conversion,
+        wfg.use_cache,
+        wfg._cache,
+        wfg.waveform_arguments,
+    )
+    return children, aux_data
+
+
+def wfg_unflatten(aux_data, children) -> WaveformGenerator:
+    wfg = WaveformGenerator.__new__(WaveformGenerator)
+    wfg._times_and_frequencies = aux_data[0]
+    wfg.frequency_domain_source_model = aux_data[1]
+    wfg.time_domain_source_model = aux_data[2]
+    wfg.source_parameter_keys = aux_data[3]
+    wfg.parameter_conversion = aux_data[4]
+    wfg.use_cache = aux_data[5]
+    wfg._cache = aux_data[6]
+    wfg.waveform_arguments = aux_data[7]
+    return wfg
+
+
+for tpl in [
+    (GravitationalWaveTransient, likelihood_flatten, likelihood_unflatten),
+    (InterferometerList, interferometer_list_flatten, interferometer_list_unflatten),
+    (Interferometer, interferometer_flatten, interferometer_unflatten),
+    (InterferometerStrainData, strain_data_flatten, strain_data_unflatten),
+    (PowerSpectralDensity, psd_flatten, psd_unflatten),
+    (InterferometerGeometry, geometry_flatten, geometry_unflatten),
+    (Recalibrate, recalibrate_flatten, recalibrate_unflatten),
+    (NotchList, notch_list_flatten, notch_list_unflatten),
+    (WaveformGenerator, wfg_flatten, wfg_unflatten),
+]:
+    register_pytree_node(*tpl)

--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -616,9 +616,11 @@ class Interferometer(object):
         =======
         float: The optimal signal to noise ratio possible squared
         """
+        mask = self.strain_data.frequency_mask
+        xp = array_module(signal)
         return gwutils.optimal_snr_squared(
-            signal=signal[self.strain_data.frequency_mask],
-            power_spectral_density=self.power_spectral_density_array[self.strain_data.frequency_mask],
+            signal=signal * mask,
+            power_spectral_density=xp.where(mask, self.power_spectral_density_array, xp.inf),
             duration=self.strain_data.duration)
 
     def inner_product(self, signal):
@@ -633,10 +635,12 @@ class Interferometer(object):
         =======
         float: The optimal signal to noise ratio possible squared
         """
+        mask = self.strain_data.frequency_mask
+        xp = array_module(signal)
         return gwutils.noise_weighted_inner_product(
-            aa=signal[self.strain_data.frequency_mask],
-            bb=self.strain_data.frequency_domain_strain[self.strain_data.frequency_mask],
-            power_spectral_density=self.power_spectral_density_array[self.strain_data.frequency_mask],
+            aa=signal * mask,
+            bb=self.strain_data.frequency_domain_strain * mask,
+            power_spectral_density=xp.where(mask, self.power_spectral_density_array, xp.inf),
             duration=self.strain_data.duration)
 
     def template_template_inner_product(self, signal_1, signal_2):

--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -602,9 +602,11 @@ class Interferometer(object):
         =======
         float: The optimal signal to noise ratio possible squared
         """
+        mask = self.strain_data.frequency_mask
+        xp = array_module(signal)
         return gwutils.optimal_snr_squared(
-            signal=signal[self.strain_data.frequency_mask],
-            power_spectral_density=self.power_spectral_density_array[self.strain_data.frequency_mask],
+            signal=signal * mask,
+            power_spectral_density=xp.where(mask, self.power_spectral_density_array, xp.inf),
             duration=self.strain_data.duration)
 
     def inner_product(self, signal):
@@ -619,10 +621,12 @@ class Interferometer(object):
         =======
         float: The optimal signal to noise ratio possible squared
         """
+        mask = self.strain_data.frequency_mask
+        xp = array_module(signal)
         return gwutils.noise_weighted_inner_product(
-            aa=signal[self.strain_data.frequency_mask],
-            bb=self.strain_data.frequency_domain_strain[self.strain_data.frequency_mask],
-            power_spectral_density=self.power_spectral_density_array[self.strain_data.frequency_mask],
+            aa=signal * mask,
+            bb=self.strain_data.frequency_domain_strain * mask,
+            power_spectral_density=xp.where(mask, self.power_spectral_density_array, xp.inf),
             duration=self.strain_data.duration)
 
     def template_template_inner_product(self, signal_1, signal_2):

--- a/bilby/gw/detector/psd.py
+++ b/bilby/gw/detector/psd.py
@@ -369,8 +369,8 @@ class PowerSpectralDensity(object):
             frequency_domain_strain = self._power_spectral_density_interpolated(frequencies) ** 0.5 * white_noise
         xp = aac.array_namespace(frequency_domain_strain)
         out_of_bounds = (
-            (frequencies < xp.min(self.frequency_array))
-            | (frequencies > xp.max(self.frequency_array))
+            (frequencies < self.frequency_array.min())
+            | (frequencies > self.frequency_array.max())
         )
         frequency_domain_strain = xpx.at(frequency_domain_strain, out_of_bounds).set(0j)
         return xp.nan_to_num(frequency_domain_strain), xp.asarray(frequencies)

--- a/bilby/gw/detector/psd.py
+++ b/bilby/gw/detector/psd.py
@@ -369,8 +369,8 @@ class PowerSpectralDensity(object):
             frequency_domain_strain = self._power_spectral_density_interpolated(frequencies) ** 0.5 * white_noise
         xp = aac.array_namespace(frequency_domain_strain)
         out_of_bounds = (
-            (frequencies < self.frequency_array.min())
-            | (frequencies > self.frequency_array.max())
+            (frequencies < xp.min(self.frequency_array))
+            | (frequencies > xp.max(self.frequency_array))
         )
         frequency_domain_strain = xpx.at(frequency_domain_strain, out_of_bounds).set(0j)
         return xp.nan_to_num(frequency_domain_strain), xp.asarray(frequencies)

--- a/bilby/gw/detector/psd.py
+++ b/bilby/gw/detector/psd.py
@@ -370,8 +370,8 @@ class PowerSpectralDensity(object):
             frequency_domain_strain = self._power_spectral_density_interpolated(frequencies) ** 0.5 * white_noise
         xp = aac.array_namespace(frequency_domain_strain)
         out_of_bounds = (
-            (frequencies < xp.min(self.frequency_array))
-            | (frequencies > xp.max(self.frequency_array))
+            (frequencies < self.frequency_array.min())
+            | (frequencies > self.frequency_array.max())
         )
         frequency_domain_strain = xpx.at(frequency_domain_strain, out_of_bounds).set(0j)
         return xp.nan_to_num(frequency_domain_strain), xp.asarray(frequencies)

--- a/bilby/gw/detector/psd.py
+++ b/bilby/gw/detector/psd.py
@@ -370,8 +370,8 @@ class PowerSpectralDensity(object):
             frequency_domain_strain = self._power_spectral_density_interpolated(frequencies) ** 0.5 * white_noise
         xp = aac.array_namespace(frequency_domain_strain)
         out_of_bounds = (
-            (frequencies < self.frequency_array.min())
-            | (frequencies > self.frequency_array.max())
+            (frequencies < xp.min(self.frequency_array))
+            | (frequencies > xp.max(self.frequency_array))
         )
         frequency_domain_strain = xpx.at(frequency_domain_strain, out_of_bounds).set(0j)
         return xp.nan_to_num(frequency_domain_strain), xp.asarray(frequencies)

--- a/bilby/gw/detector/strain_data.py
+++ b/bilby/gw/detector/strain_data.py
@@ -650,7 +650,7 @@ class InterferometerStrainData(object):
             'power_spectal_density')
         frequency_domain_strain, frequency_array = \
             power_spectral_density.get_noise_realisation(
-                self.frequency_array.shape[0], self.duration, random_state=random_state)
+                self.frequency_array.shape[0], duration, random_state=random_state)
 
         xp = aac.array_namespace(frequency_domain_strain)
         self._frequency_array = xp.asarray(self.frequency_array)

--- a/bilby/gw/likelihood/base.py
+++ b/bilby/gw/likelihood/base.py
@@ -1070,13 +1070,15 @@ class GravitationalWaveTransient(Likelihood):
     def _reference_frame_str(self):
         if isinstance(self.reference_frame, str):
             return self.reference_frame
+        elif self.reference_frame is None:
+            return "sky"
         else:
             return "".join([ifo.name for ifo in self.reference_frame])
 
     @reference_frame.setter
     def reference_frame(self, frame):
         if frame == "sky":
-            self._reference_frame = frame
+            self._reference_frame = None
         elif isinstance(frame, InterferometerList):
             self._reference_frame = frame[:2]
         elif isinstance(frame, list):

--- a/bilby/gw/likelihood/base.py
+++ b/bilby/gw/likelihood/base.py
@@ -1112,7 +1112,7 @@ class GravitationalWaveTransient(Likelihood):
                 f"Cannot find {self.time_reference}_time in parameters. "
                 "Falling back to geocent time"
             )
-        if not self.reference_frame == "sky":
+        if self.reference_frame is not None:
             try:
                 ra, dec = zenith_azimuth_to_ra_dec(
                     parameters['zenith'], parameters['azimuth'],

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -15,7 +15,7 @@ from ..core.prior import (
     ConditionalPriorDict, ConditionalBasePrior, BaseJointPriorDist, JointPrior,
     JointPriorDistError,
 )
-from ..core.utils import infer_args_from_method, logger, random, WrappedInterp1d as interp1d
+from ..core.utils import infer_args_from_method, logger, random, interp1d
 from .conversion import (
     convert_to_lal_binary_black_hole_parameters,
     convert_to_lal_binary_neutron_star_parameters, generate_mass_parameters,
@@ -362,6 +362,8 @@ class UniformInComponentsChirpMass(PowerLaw):
     :code:`bilby.gw.prior.UniformInComponentsMassRatio`.
     """
 
+    _leaves = ["_minimum", "_maximum", "alpha"]
+
     def __init__(self, minimum, maximum, name='chirp_mass',
                  latex_label=r'$\mathcal{M}$', unit=None, boundary=None):
         """
@@ -397,6 +399,8 @@ class UniformInComponentsMassRatio(Prior):
     This prior is intended to be used in conjunction with the corresponding
     :code:`bilby.gw.prior.UniformInComponentsChirpMass`.
     """
+
+    _leaves = ["norm", "icdf"]
 
     def __init__(self, minimum, maximum, name='mass_ratio', latex_label='$q$',
                  unit=None, boundary=None, equal_mass=False):
@@ -471,6 +475,8 @@ class AlignedSpin(Interped):
     For the simple case of uniform in magnitude and orientation priors, we use an
     analytic form of the PDF.
     """
+
+    _leaves = Interped._leaves + ["a_prior", "z_prior"]    
 
     def __init__(
         self,

--- a/bilby/gw/prior.py
+++ b/bilby/gw/prior.py
@@ -476,7 +476,7 @@ class AlignedSpin(Interped):
     analytic form of the PDF.
     """
 
-    _leaves = Interped._leaves + ["a_prior", "z_prior"]    
+    _leaves = Interped._leaves + ["a_prior", "z_prior"]
 
     def __init__(
         self,

--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -188,7 +188,7 @@ class WaveformGenerator(object):
             and self._cache['transformed_model'] == transformed_model
         ):
             return self._cache['waveform']
-        else:
+        elif self.use_cache:
             self._cache['parameters'] = parameters.copy()
             self._cache['model'] = model
             self._cache['transformed_model'] = transformed_model
@@ -205,7 +205,8 @@ class WaveformGenerator(object):
             )
         else:
             raise RuntimeError("No source model given")
-        self._cache['waveform'] = model_strain
+        if self.use_cache:
+            self._cache['waveform'] = model_strain
         return model_strain
 
     def _strain_from_model(self, model_data_points, model, parameters, *, xp=None):

--- a/bilby/hyper/compat/pytrees.py
+++ b/bilby/hyper/compat/pytrees.py
@@ -1,0 +1,54 @@
+from jax.tree_util import register_pytree_node
+
+from ...compat.pytrees import likelihood_flatten, likelihood_unflatten
+from ..likelihood import HyperparameterLikelihood
+from ..model import Model
+
+
+def hyperparameter_likelihood_flatten(likelihood: HyperparameterLikelihood):
+    _, aux_data = likelihood_flatten(likelihood)
+    children = (
+        likelihood.data,
+        likelihood.evidence_factor,
+        likelihood.posteriors,
+        likelihood.samples_factor,
+        likelihood.hyper_prior,
+    )
+    aux_data += (
+        likelihood.sampling_prior,
+    )
+    return children, aux_data
+
+
+def hyperparameter_likelihood_unflatten(aux_data, flat) -> HyperparameterLikelihood:
+    likelihood = likelihood_unflatten(aux_data, flat)
+    data, evidence_factor, posteriors, samples_factor, hyper_prior = flat[:5]
+    sampling_prior = aux_data[2]
+    likelihood.data = data
+    likelihood.evidence_factor = evidence_factor
+    likelihood.posteriors = posteriors
+    likelihood.samples_factor = samples_factor
+    likelihood.hyper_prior = hyper_prior
+    likelihood.sampling_prior = sampling_prior
+    likelihood.n_posteriors = data["prior"].shape[0]
+    likelihood.max_samples = data["prior"].shape[1]
+    likelihood.samples_per_posterior = data["prior"].shape[1]
+    return likelihood
+
+
+def model_flatten(model: Model):
+    aux_data = tuple(model.models)
+    return (), aux_data
+
+
+def model_unflatten(aux_data, flat) -> Model:
+    model = Model.__new__(Model)
+    model.cache = False
+    model.models = list(aux_data)
+    return model
+
+
+register_pytree_node(
+    HyperparameterLikelihood, hyperparameter_likelihood_flatten, hyperparameter_likelihood_unflatten
+)
+register_pytree_node(Model, model_flatten, model_unflatten)

--- a/bilby/hyper/compat/pytrees.py
+++ b/bilby/hyper/compat/pytrees.py
@@ -1,6 +1,6 @@
 from jax.tree_util import register_pytree_node
 
-from ...compat.pytrees import likelihood_flatten, likelihood_unflatten
+from ...compat.pytrees.likelihood import likelihood_flatten, likelihood_unflatten
 from ..likelihood import HyperparameterLikelihood
 from ..model import Model
 

--- a/test/core/likelihood_test.py
+++ b/test/core/likelihood_test.py
@@ -27,12 +27,12 @@ def _evaluate_with_jit(likelihood, parameters, xp):
 
     import jax
 
-    from bilby.compat.pytrees import likelihood as _
+    from bilby.compat.pytrees import likelihood as _  # noqa
 
     @jax.jit
     def jit_fn(likelihood, parameters):
         return likelihood.log_likelihood(parameters)
-    
+
     expected = likelihood.log_likelihood(parameters)
     jitted = jit_fn(likelihood, parameters)
     jitted = jit_fn(likelihood, parameters)
@@ -665,10 +665,12 @@ class TestAnalyticalMultidimensionalBimodalCovariantGaussian(unittest.TestCase):
         _evaluate_with_jit(self.likelihood, self.parameters, self.xp)
 
 
+@pytest.mark.array_backend
+@pytest.mark.usefixtures("xp_class")
 class TestJointLikelihood(unittest.TestCase):
     def setUp(self):
-        self.x = np.array([1, 2, 3])
-        self.y = np.array([1, 2, 3])
+        self.x = self.xp.array([1, 2, 3])
+        self.y = self.xp.array([1, 2, 3])
         self.first_likelihood = GaussianLikelihood(
             x=self.x,
             y=self.y,

--- a/test/core/likelihood_test.py
+++ b/test/core/likelihood_test.py
@@ -21,6 +21,25 @@ from bilby.core.likelihood import (
 )
 
 
+def _evaluate_with_jit(likelihood, parameters, xp):
+    if not aac.is_jax_namespace(xp):
+        pytest.skip("JIT test only runs for JAX backend")
+
+    import jax
+
+    from bilby.compat.pytrees import likelihood as _
+
+    @jax.jit
+    def jit_fn(likelihood, parameters):
+        return likelihood.log_likelihood(parameters)
+    
+    expected = likelihood.log_likelihood(parameters)
+    jitted = jit_fn(likelihood, parameters)
+    jitted = jit_fn(likelihood, parameters)
+
+    assert xp.abs(expected - jitted) < 1e-12
+
+
 class TestLikelihoodBase(unittest.TestCase):
     def setUp(self):
         self.likelihood = Likelihood()
@@ -182,8 +201,12 @@ class TestGaussianLikelihood(unittest.TestCase):
         del self.y
         del self.function
 
+    @property
+    def default_likelihood(self):
+        return GaussianLikelihood(self.x, self.y, self.function, self.sigma)
+
     def test_known_sigma(self):
-        likelihood = GaussianLikelihood(self.x, self.y, self.function, self.sigma)
+        likelihood = self.default_likelihood
         parameters = dict(m=2, c=0)
         likelihood.log_likelihood(parameters)
         self.assertEqual(likelihood.sigma, self.sigma)
@@ -214,16 +237,19 @@ class TestGaussianLikelihood(unittest.TestCase):
             likelihood.sigma = "test"
 
     def test_repr(self):
-        likelihood = GaussianLikelihood(self.x, self.y, self.function, sigma=self.sigma)
+        likelihood = self.default_likelihood
         expected = "GaussianLikelihood(x={}, y={}, func={}, sigma={})".format(
             self.x, self.y, self.function.__name__, self.sigma
         )
         self.assertEqual(expected, repr(likelihood))
 
     def test_return_class(self):
-        likelihood = GaussianLikelihood(self.x, self.y, self.function, self.sigma)
+        likelihood = self.default_likelihood
         logl = likelihood.log_likelihood(self.parameters)
         self.assertEqual(aac.get_namespace(logl), self.xp)
+
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.default_likelihood, self.parameters, self.xp)
 
 
 @pytest.mark.array_backend
@@ -249,10 +275,12 @@ class TestStudentTLikelihood(unittest.TestCase):
         del self.y
         del self.function
 
+    @property
+    def default_likelihood(self):
+        return StudentTLikelihood(self.x, self.y, self.function, self.nu, self.sigma)
+
     def test_known_sigma(self):
-        likelihood = StudentTLikelihood(
-            self.x, self.y, self.function, self.nu, self.sigma
-        )
+        likelihood = self.default_likelihood
         parameters = dict(m=2, c=0)
         likelihood.log_likelihood(parameters)
         self.assertEqual(likelihood.sigma, self.sigma)
@@ -300,6 +328,9 @@ class TestStudentTLikelihood(unittest.TestCase):
         )
         self.assertEqual(expected, repr(likelihood))
 
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.default_likelihood, self.parameters, self.xp)
+
 
 @pytest.mark.array_backend
 @pytest.mark.usefixtures("xp_class")
@@ -322,6 +353,7 @@ class TestPoissonLikelihood(unittest.TestCase):
         self.function = test_function
         self.function_array = test_function_array
         self.poisson_likelihood = PoissonLikelihood(self.x, self.y, self.function)
+        self.parameters = dict(c=self.xp.asarray(2.0))
         self.bad_parameters = dict(c=self.xp.asarray(-2.0))
 
     def tearDown(self):
@@ -351,6 +383,9 @@ class TestPoissonLikelihood(unittest.TestCase):
             self.poisson_likelihood.log_likelihood(parameters)
 
     def test_neg_rate_array(self):
+        if aac.is_jax_namespace(self.xp):
+            pytest.skip("JAX doesn't raise an error here")
+
         likelihood = PoissonLikelihood(self.x, self.y, self.function_array)
         parameters = dict(c=-2)
         with self.assertRaises(ValueError):
@@ -388,15 +423,18 @@ class TestPoissonLikelihood(unittest.TestCase):
             poisson_likelihood.log_likelihood(dict())
 
     def test_log_likelihood_negative_func_return_element(self):
+        if aac.is_jax_namespace(self.xp):
+            pytest.skip("JAX doesn't raise an error here")
+
         poisson_likelihood = PoissonLikelihood(
-            x=self.x, y=self.y, func=lambda x: self.xp.asarray([3, 6, -2])
+            x=self.x, y=self.y, func=lambda x: xpx.at(self.x, -1).set(-1)
         )
         with self.assertRaises(ValueError):
             poisson_likelihood.log_likelihood(dict())
 
     def test_log_likelihood_zero_func_return_element(self):
         poisson_likelihood = PoissonLikelihood(
-            x=self.x, y=self.y, func=lambda x: self.xp.asarray([3, 6, 0])
+            x=self.x, y=self.y, func=lambda x: xpx.at(self.x, -1).set(0)
         )
         self.assertEqual(-np.inf, poisson_likelihood.log_likelihood(dict()))
 
@@ -415,6 +453,9 @@ class TestPoissonLikelihood(unittest.TestCase):
             self.x, self.y, self.function.__name__
         )
         self.assertEqual(expected, repr(likelihood))
+
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.poisson_likelihood, self.parameters, self.xp)
 
 
 @pytest.mark.array_backend
@@ -439,7 +480,12 @@ class TestExponentialLikelihood(unittest.TestCase):
         self.exponential_likelihood = ExponentialLikelihood(
             x=self.x, y=self.y, func=self.function
         )
+        self.parameters = dict(c=self.xp.asarray(1.0))
         self.bad_parameters = dict(c=self.xp.asarray(-1.0))
+
+    @property
+    def default_likelihood(self):
+        return ExponentialLikelihood(self.x, self.y, self.function)
 
     def tearDown(self):
         del self.N
@@ -455,7 +501,7 @@ class TestExponentialLikelihood(unittest.TestCase):
             ExponentialLikelihood(self.x, self.yneg, self.function)
 
     def test_negative_function(self):
-        likelihood = ExponentialLikelihood(self.x, self.y, self.function)
+        likelihood = self.default_likelihood
         parameters = dict(c=-1)
         self.assertEqual(likelihood.log_likelihood(parameters), -np.inf)
 
@@ -513,6 +559,9 @@ class TestExponentialLikelihood(unittest.TestCase):
         )
         self.assertEqual(expected, repr(self.exponential_likelihood))
 
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.default_likelihood, self.parameters, self.xp)
+
 
 @pytest.mark.array_backend
 @pytest.mark.usefixtures("xp_class")
@@ -528,6 +577,7 @@ class TestAnalyticalMultidimensionalCovariantGaussian(unittest.TestCase):
         self.likelihood = AnalyticalMultidimensionalCovariantGaussian(
             mean=self.mean, cov=self.cov
         )
+        self.parameters = {f"x{ii}": self.xp.asarray(9.0) for ii in range(3)}
 
     def tearDown(self):
         del self.cov
@@ -558,6 +608,9 @@ class TestAnalyticalMultidimensionalCovariantGaussian(unittest.TestCase):
         )
         self.assertEqual(aac.get_namespace(logl), self.xp)
 
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.likelihood, self.parameters, self.xp)
+
 
 @pytest.mark.array_backend
 @pytest.mark.usefixtures("xp_class")
@@ -575,6 +628,7 @@ class TestAnalyticalMultidimensionalBimodalCovariantGaussian(unittest.TestCase):
         self.likelihood = AnalyticalMultidimensionalBimodalCovariantGaussian(
             mean_1=self.mean_1, mean_2=self.mean_2, cov=self.cov
         )
+        self.parameters = {f"x{ii}": self.xp.asarray(9.0) for ii in range(3)}
 
     def tearDown(self):
         del self.cov
@@ -606,6 +660,9 @@ class TestAnalyticalMultidimensionalBimodalCovariantGaussian(unittest.TestCase):
             -np.log(2 * np.pi) / 2,
             likelihood.log_likelihood(dict(x0=self.xp.asarray(0.0))),
         )
+
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.likelihood, self.parameters, self.xp)
 
 
 class TestJointLikelihood(unittest.TestCase):
@@ -686,6 +743,9 @@ class TestJointLikelihood(unittest.TestCase):
     def test_setting_likelihood_other(self):
         with self.assertRaises(ValueError):
             self.joint_likelihood.likelihoods = "test"
+
+    def test_jitted_likelihood(self):
+        _evaluate_with_jit(self.joint_likelihood, self.parameters, self.xp)
 
 
 class TestGPLikelihood(unittest.TestCase):

--- a/test/core/likelihood_test.py
+++ b/test/core/likelihood_test.py
@@ -669,8 +669,8 @@ class TestAnalyticalMultidimensionalBimodalCovariantGaussian(unittest.TestCase):
 @pytest.mark.usefixtures("xp_class")
 class TestJointLikelihood(unittest.TestCase):
     def setUp(self):
-        self.x = self.xp.array([1, 2, 3])
-        self.y = self.xp.array([1, 2, 3])
+        self.x = self.xp.asarray([1, 2, 3])
+        self.y = self.xp.asarray([1, 2, 3])
         self.first_likelihood = GaussianLikelihood(
             x=self.x,
             y=self.y,

--- a/test/core/likelihood_test.py
+++ b/test/core/likelihood_test.py
@@ -34,10 +34,21 @@ def _evaluate_with_jit(likelihood, parameters, xp):
         return likelihood.log_likelihood(parameters)
 
     expected = likelihood.log_likelihood(parameters)
-    jitted = jit_fn(likelihood, parameters)
-    jitted = jit_fn(likelihood, parameters)
 
+    cache_size = jit_fn._cache_size()
+    jitted = jit_fn(likelihood, parameters)
+    jitted = jit_fn(likelihood, parameters)
     assert xp.abs(expected - jitted) < 1e-12
+
+    alt_likelihood = deepcopy(likelihood)
+    alt_likelihood.interferometers.set_strain_data_from_power_spectral_densities(
+        duration=alt_likelihood.interferometers.duration,
+        sampling_frequency=alt_likelihood.interferometers.sampling_frequency,
+    )
+    new_value = jit_fn(alt_likelihood, parameters)
+
+    new_cache_size = jit_fn._cache_size()
+    assert new_cache_size <= cache_size + 1, "Cache size increased by more than 1"
 
 
 class TestLikelihoodBase(unittest.TestCase):

--- a/test/core/likelihood_test.py
+++ b/test/core/likelihood_test.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import deepcopy
 from unittest import mock
 
 import array_api_compat as aac
@@ -36,19 +37,18 @@ def _evaluate_with_jit(likelihood, parameters, xp):
     expected = likelihood.log_likelihood(parameters)
 
     cache_size = jit_fn._cache_size()
+    # call the function twice so that we test with and without compilation
     jitted = jit_fn(likelihood, parameters)
     jitted = jit_fn(likelihood, parameters)
     assert xp.abs(expected - jitted) < 1e-12
 
+    # call with a copy of the likelihood to make sure it doesn't retrigger a compilation
     alt_likelihood = deepcopy(likelihood)
-    alt_likelihood.interferometers.set_strain_data_from_power_spectral_densities(
-        duration=alt_likelihood.interferometers.duration,
-        sampling_frequency=alt_likelihood.interferometers.sampling_frequency,
-    )
     new_value = jit_fn(alt_likelihood, parameters)
 
     new_cache_size = jit_fn._cache_size()
     assert new_cache_size <= cache_size + 1, "Cache size increased by more than 1"
+    assert new_value == jitted
 
 
 class TestLikelihoodBase(unittest.TestCase):

--- a/test/core/prior/analytical_test.py
+++ b/test/core/prior/analytical_test.py
@@ -276,6 +276,5 @@ def test_powerlaw_small_values(xp, alpha):
     assert xp.all(xp.isfinite(ln_prob[val >= prior.minimum]))
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/core/prior/analytical_test.py
+++ b/test/core/prior/analytical_test.py
@@ -266,5 +266,16 @@ class TestWeightedCategoricalPrior(unittest.TestCase):
         self.assertEqual(type(new), type(original))
 
 
+@pytest.mark.parametrize("alpha", [-1, -0.5, 0, 1, 2])
+def test_powerlaw_small_values(xp, alpha):
+    prior = bilby.core.prior.PowerLaw(alpha=alpha, minimum=1e-10, maximum=1)
+    val = xp.array([1e-10, 1e-5, 1e-1])
+    prob = prior.prob(val)
+    ln_prob = prior.ln_prob(val)
+    assert xp.all(xp.isfinite(prob[val >= prior.minimum]))
+    assert xp.all(xp.isfinite(ln_prob[val >= prior.minimum]))
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -60,9 +60,9 @@ class TestPriorClasses(unittest.TestCase):
             bilby.core.prior.PowerLaw(
                 name="test", unit="unit", alpha=0, minimum=0, maximum=1
             ),
-            bilby.core.prior.PowerLaw(
-                name="test", unit="unit", alpha=-1, minimum=0.5, maximum=1
-            ),
+            # bilby.core.prior.PowerLaw(
+            #     name="test", unit="unit", alpha=-1, minimum=0.5, maximum=1
+            # ),
             bilby.core.prior.PowerLaw(
                 name="test", unit="unit", alpha=2, minimum=1, maximum=1e2
             ),
@@ -138,14 +138,14 @@ class TestPriorClasses(unittest.TestCase):
                 minimum=0,
                 maximum=1,
             ),
-            bilby.core.prior.ConditionalPowerLaw(
-                condition_func=condition_func,
-                name="test",
-                unit="unit",
-                alpha=-1,
-                minimum=0.5,
-                maximum=1,
-            ),
+            # bilby.core.prior.ConditionalPowerLaw(
+            #     condition_func=condition_func,
+            #     name="test",
+            #     unit="unit",
+            #     alpha=-1,
+            #     minimum=0.5,
+            #     maximum=1,
+            # ),
             bilby.core.prior.ConditionalPowerLaw(
                 condition_func=condition_func,
                 name="test",
@@ -267,6 +267,30 @@ class TestPriorClasses(unittest.TestCase):
 
     def tearDown(self):
         del self.priors
+
+    def test_jits(self):
+        if not aac.is_jax_namespace(self.xp):
+            pytest.skip("Jitting test only works with JAX")
+        
+        import jax
+        from bilby.compat import pytrees as _
+
+        @jax.jit
+        def evaluate_prior(prior_, val):
+            return prior_.prob(val)
+
+        for prior in self.priors:
+            if isinstance(prior, bilby.core.prior.JointPrior):
+                continue
+            cache_size = evaluate_prior._cache_size()
+            sample = jax.numpy.asarray(prior.sample(3))
+            _ = evaluate_prior(prior, sample)
+            from copy import deepcopy
+            alt_prior = deepcopy(prior)
+            sample = jax.numpy.asarray(alt_prior.sample(3))
+            _ = evaluate_prior(alt_prior, sample)
+            new_cache_size = evaluate_prior._cache_size()
+            assert new_cache_size <= cache_size + 1, f"Cache size increased by more than 1 for {prior.__class__.__name__}"
 
     def _validate_return_type(self, val):
         if not isinstance(val, (int, float)):

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -1,8 +1,10 @@
+import os
+import unittest
+from copy import deepcopy
+
 import array_api_compat as aac
 import bilby
-import unittest
 import numpy as np
-import os
 import pytest
 import scipy.stats as ss
 from scipy.integrate import trapezoid
@@ -271,9 +273,9 @@ class TestPriorClasses(unittest.TestCase):
     def test_jits(self):
         if not aac.is_jax_namespace(self.xp):
             pytest.skip("Jitting test only works with JAX")
-        
+
         import jax
-        from bilby.compat import pytrees as _
+        from bilby.compat import pytrees  # noqa
 
         @jax.jit
         def evaluate_prior(prior_, val):
@@ -284,13 +286,13 @@ class TestPriorClasses(unittest.TestCase):
                 continue
             cache_size = evaluate_prior._cache_size()
             sample = jax.numpy.asarray(prior.sample(3))
-            _ = evaluate_prior(prior, sample)
-            from copy import deepcopy
+            evaluate_prior(prior, sample)
             alt_prior = deepcopy(prior)
             sample = jax.numpy.asarray(alt_prior.sample(3))
-            _ = evaluate_prior(alt_prior, sample)
+            evaluate_prior(alt_prior, sample)
             new_cache_size = evaluate_prior._cache_size()
-            assert new_cache_size <= cache_size + 1, f"Cache size increased by more than 1 for {prior.__class__.__name__}"
+            message = f"Cache size increased by more than 1 for {prior.__class__.__name__}"
+            assert new_cache_size <= cache_size + 1, message
 
     def _validate_return_type(self, val):
         if not isinstance(val, (int, float)):

--- a/test/core/prior/prior_test.py
+++ b/test/core/prior/prior_test.py
@@ -62,9 +62,9 @@ class TestPriorClasses(unittest.TestCase):
             bilby.core.prior.PowerLaw(
                 name="test", unit="unit", alpha=0, minimum=0, maximum=1
             ),
-            # bilby.core.prior.PowerLaw(
-            #     name="test", unit="unit", alpha=-1, minimum=0.5, maximum=1
-            # ),
+            bilby.core.prior.PowerLaw(
+                name="test", unit="unit", alpha=-1, minimum=0.5, maximum=1
+            ),
             bilby.core.prior.PowerLaw(
                 name="test", unit="unit", alpha=2, minimum=1, maximum=1e2
             ),
@@ -140,14 +140,14 @@ class TestPriorClasses(unittest.TestCase):
                 minimum=0,
                 maximum=1,
             ),
-            # bilby.core.prior.ConditionalPowerLaw(
-            #     condition_func=condition_func,
-            #     name="test",
-            #     unit="unit",
-            #     alpha=-1,
-            #     minimum=0.5,
-            #     maximum=1,
-            # ),
+            bilby.core.prior.ConditionalPowerLaw(
+                condition_func=condition_func,
+                name="test",
+                unit="unit",
+                alpha=-1,
+                minimum=0.5,
+                maximum=1,
+            ),
             bilby.core.prior.ConditionalPowerLaw(
                 condition_func=condition_func,
                 name="test",

--- a/test/gw/detector/interferometer_test.py
+++ b/test/gw/detector/interferometer_test.py
@@ -312,9 +312,9 @@ class TestInterferometer(unittest.TestCase):
             signal = np.ones_like(self.ifo.power_spectral_density_array)
             mask = self.ifo.frequency_mask
             expected = [
-                signal[mask],
-                signal[mask],
-                self.ifo.power_spectral_density_array[mask],
+                signal * mask,
+                signal * mask,
+                np.where(mask, self.ifo.power_spectral_density_array, np.inf),
                 self.ifo.strain_data.duration,
             ]
             actual = self.ifo.optimal_snr_squared(signal=signal)
@@ -331,9 +331,9 @@ class TestInterferometer(unittest.TestCase):
             signal_1=signal_1,
             signal_2=signal_1
         )
-        self.assertTrue(np.array_equal(signal_1_optimal, signal_1_optimal_by_template_template))
+        self.assertAlmostEqual(signal_1_optimal, signal_1_optimal_by_template_template, delta=signal_1_optimal / 1e14)
         signal_1_signal_2_inner_product = self.ifo.template_template_inner_product(signal_1=signal_1, signal_2=signal_2)
-        self.assertTrue(np.array_equal(signal_1_optimal * 2, signal_1_signal_2_inner_product))
+        self.assertAlmostEqual(signal_1_optimal * 2, signal_1_signal_2_inner_product, delta=signal_1_optimal / 1e14)
 
     def test_repr(self):
         expected = (

--- a/test/gw/detector/interferometer_test.py
+++ b/test/gw/detector/interferometer_test.py
@@ -311,9 +311,9 @@ class TestInterferometer(unittest.TestCase):
             signal = np.ones_like(self.ifo.power_spectral_density_array)
             mask = self.ifo.frequency_mask
             expected = [
-                signal[mask],
-                signal[mask],
-                self.ifo.power_spectral_density_array[mask],
+                signal * mask,
+                signal * mask,
+                np.where(mask, self.ifo.power_spectral_density_array, np.inf),
                 self.ifo.strain_data.duration,
             ]
             actual = self.ifo.optimal_snr_squared(signal=signal)
@@ -330,9 +330,9 @@ class TestInterferometer(unittest.TestCase):
             signal_1=signal_1,
             signal_2=signal_1
         )
-        self.assertTrue(np.array_equal(signal_1_optimal, signal_1_optimal_by_template_template))
+        self.assertAlmostEqual(signal_1_optimal, signal_1_optimal_by_template_template, delta=signal_1_optimal / 1e14)
         signal_1_signal_2_inner_product = self.ifo.template_template_inner_product(signal_1=signal_1, signal_2=signal_2)
-        self.assertTrue(np.array_equal(signal_1_optimal * 2, signal_1_signal_2_inner_product))
+        self.assertAlmostEqual(signal_1_optimal * 2, signal_1_signal_2_inner_product, delta=signal_1_optimal / 1e14)
 
     def test_repr(self):
         expected = (

--- a/test/gw/likelihood/jit_test.py
+++ b/test/gw/likelihood/jit_test.py
@@ -14,15 +14,14 @@ def _evaluate_with_jit(likelihood, parameters, xp):
         pytest.skip("JIT test only runs for JAX backend")
 
     import jax
-    from jax.tree_util import register_pytree_node
 
-    from bilby.compat.pytrees import likelihood as _
-    from bilby.gw.compat import pytrees as _
+    from bilby.compat.pytrees import likelihood as _  # noqa
+    from bilby.gw.compat import pytrees as _  # noqa
 
     @jax.jit
     def jit_fn(likelihood, parameters):
         return likelihood.log_likelihood_ratio(parameters)
-    
+
     expected = likelihood.log_likelihood_ratio(parameters)
     jitted = jit_fn(likelihood, parameters)
     jitted = jit_fn(likelihood, parameters)

--- a/test/gw/likelihood/jit_test.py
+++ b/test/gw/likelihood/jit_test.py
@@ -1,0 +1,96 @@
+import array_api_compat as aac
+import numpy as np
+import pytest
+from bilby.core.prior import PriorDict, Uniform
+from bilby.core.utils.random import seed
+from bilby.gw.detector import InterferometerList
+from bilby.gw.likelihood import GravitationalWaveTransient
+from bilby.gw.source import sinegaussian
+from bilby.gw.waveform_generator import WaveformGenerator
+
+
+def _evaluate_with_jit(likelihood, parameters, xp):
+    if not aac.is_jax_namespace(xp):
+        pytest.skip("JIT test only runs for JAX backend")
+
+    import jax
+    from jax.tree_util import register_pytree_node
+
+    from bilby.compat.pytrees import likelihood as _
+    from bilby.gw.compat import pytrees as _
+
+    @jax.jit
+    def jit_fn(likelihood, parameters):
+        return likelihood.log_likelihood_ratio(parameters)
+    
+    expected = likelihood.log_likelihood_ratio(parameters)
+    jitted = jit_fn(likelihood, parameters)
+    jitted = jit_fn(likelihood, parameters)
+
+    assert xp.abs(expected - jitted) < 1e-10
+
+
+def null_convert(parameters):
+    return parameters, list()
+
+
+def likelihood(xp, **marginalizations):
+    seed(500)
+    interferometers = InterferometerList(["H1"])
+    interferometers.set_strain_data_from_power_spectral_densities(
+        sampling_frequency=xp.asarray(2048.0), duration=xp.asarray(4.0)
+    )
+    interferometers.set_array_backend(xp)
+    waveform_generator = WaveformGenerator(
+        duration=xp.asarray(4.0),
+        sampling_frequency=xp.asarray(2048.0),
+        frequency_domain_source_model=sinegaussian,
+        parameter_conversion=null_convert,
+        use_cache=False,
+    )
+    priors = PriorDict(dict(
+        phase=Uniform(0, 2 * np.pi),
+        geocent_time=Uniform(0, 4),
+    ))
+
+    likelihood = GravitationalWaveTransient(
+        interferometers=interferometers,
+        waveform_generator=waveform_generator,
+        priors=priors,
+        **marginalizations,
+    )
+    return likelihood
+
+
+@pytest.fixture
+def parameters(xp):
+    return dict(
+        hrss=1e-24,
+        Q=1.0,
+        frequency=50.0,
+        psi=xp.asarray(2.659),
+        geocent_time=xp.asarray(2.413),
+        ra=xp.asarray(1.375),
+        dec=xp.asarray(-1.2108),
+        time_jitter=0.0,
+    )
+
+
+@pytest.mark.array_backend
+def test_jitted_likelihood(xp, parameters):
+    _evaluate_with_jit(likelihood(xp), parameters, xp)
+
+
+@pytest.mark.array_backend
+def test_jitted_likelihood_with_phase_marginalization(xp, parameters):
+    _evaluate_with_jit(likelihood(xp, phase_marginalization=True), parameters, xp)
+
+
+@pytest.mark.array_backend
+def test_jitted_likelihood_with_time_marginalization(xp, parameters):
+    _evaluate_with_jit(likelihood(xp, time_marginalization=True), parameters, xp)
+
+
+@pytest.mark.array_backend
+def test_jitted_likelihood_with_phase_time_marginalization(xp, parameters):
+    _evaluate_with_jit(likelihood(xp, phase_marginalization=True, time_marginalization=True), parameters, xp)

--- a/test/gw/likelihood/jit_test.py
+++ b/test/gw/likelihood/jit_test.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import array_api_compat as aac
 import numpy as np
 import pytest
@@ -23,10 +25,25 @@ def _evaluate_with_jit(likelihood, parameters, xp):
         return likelihood.log_likelihood_ratio(parameters)
 
     expected = likelihood.log_likelihood_ratio(parameters)
-    jitted = jit_fn(likelihood, parameters)
-    jitted = jit_fn(likelihood, parameters)
 
-    assert xp.abs(expected - jitted) < 1e-10
+    cache_size = jit_fn._cache_size()
+    # call the function twice so that we test with and without compilation
+    jitted = jit_fn(likelihood, parameters)
+    jitted = jit_fn(likelihood, parameters)
+    assert xp.abs(expected - jitted) < 1e-12
+
+    # call with a copy of the likelihood with new data
+    # to make sure it doesn't retrigger a compilation
+    alt_likelihood = deepcopy(likelihood)
+    alt_likelihood.interferometers.set_strain_data_from_power_spectral_densities(
+        duration=alt_likelihood.interferometers.duration,
+        sampling_frequency=alt_likelihood.interferometers.sampling_frequency,
+    )
+    new_value = jit_fn(alt_likelihood, parameters)
+
+    new_cache_size = jit_fn._cache_size()
+    assert new_cache_size <= cache_size + 1, "Cache size increased by more than 1"
+    assert new_value != jitted
 
 
 def null_convert(parameters):

--- a/test/gw/likelihood/jit_test.py
+++ b/test/gw/likelihood/jit_test.py
@@ -30,7 +30,7 @@ def _evaluate_with_jit(likelihood, parameters, xp):
     # call the function twice so that we test with and without compilation
     jitted = jit_fn(likelihood, parameters)
     jitted = jit_fn(likelihood, parameters)
-    assert xp.abs(expected - jitted) < 1e-12
+    assert xp.abs(expected - jitted) < 1e-10
 
     # call with a copy of the likelihood with new data
     # to make sure it doesn't retrigger a compilation


### PR DESCRIPTION
This PR adds [JAX pytree definitions](https://docs.jax.dev/en/latest/custom_pytrees.html) for most classes in Bilby including:

- all (I think) priors
- all likelihoods
- the GW interferometer and waveform generator classes

Defining pytrees allows these classes to be used as inputs to JIT-compiled (or other transformations) functions and can dramatically reduce compilation/execution time.

As an example, I've used this in a case where I'm analyzing lots of events in series.
I can then JIT-compile an outer function that takes a likelihood as input and everything works smoothly.

The basic breakdown of pytree definitions relies on breaking the constituent parts of the class into leaves and auxillary data.
Any change in the auxillary data causes a recompilation, whereas leaves are traced through the functions allowing for them to be changed without recompilation.
As an example, the shape of an array would be auxillary data, but the values themselves a leaf/leaves.

**TODO**:

- [x] more testing, especially of likelihoods