### PR TITLE
BUG: Preserve complete component tidal parameters

### DIFF
--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -325,13 +325,23 @@ def convert_to_lal_binary_neutron_star_parameters(parameters):
         added_keys = added_keys + ['lambda_1', 'lambda_2']
         return converted_parameters, added_keys
 
-    if 'delta_lambda_tilde' in converted_parameters.keys():
+    have_component_lambdas = all(
+        converted_parameters.get(key) is not None
+        for key in ['lambda_1', 'lambda_2']
+    )
+    if (
+        'delta_lambda_tilde' in converted_parameters.keys()
+        and not have_component_lambdas
+    ):
         converted_parameters['lambda_1'], converted_parameters['lambda_2'] =\
             lambda_tilde_delta_lambda_tilde_to_lambda_1_lambda_2(
                 converted_parameters['lambda_tilde'],
                 parameters['delta_lambda_tilde'], converted_parameters['mass_1'],
                 converted_parameters['mass_2'])
-    elif 'lambda_tilde' in converted_parameters.keys():
+    elif (
+        'lambda_tilde' in converted_parameters.keys()
+        and not have_component_lambdas
+    ):
         converted_parameters['lambda_1'], converted_parameters['lambda_2'] =\
             lambda_tilde_to_lambda_1_lambda_2(
                 converted_parameters['lambda_tilde'],

--- a/test/gw/conversion_test.py
+++ b/test/gw/conversion_test.py
@@ -420,6 +420,36 @@ class TestConvertToLALParams(unittest.TestCase):
     def test_lambda_1(self):
         self._conversion_to_component_tidal(["lambda_1"])
 
+    def test_complete_component_tidal_parameters_take_precedence(self):
+        component_parameters = dict(
+            mass_1=7.320188129088971,
+            mass_2=1.4957247709090036,
+            lambda_1=0.0,
+            lambda_2=1097.4026147742702,
+        )
+        lambda_tilde = conversion.lambda_1_lambda_2_to_lambda_tilde(
+            **component_parameters
+        )
+        delta_lambda_tilde = conversion.lambda_1_lambda_2_to_delta_lambda_tilde(
+            **component_parameters
+        )
+
+        for derived_parameters in [
+            dict(lambda_tilde=lambda_tilde),
+            dict(
+                lambda_tilde=lambda_tilde,
+                delta_lambda_tilde=delta_lambda_tilde,
+            ),
+        ]:
+            with self.subTest(derived_parameters=derived_parameters):
+                self.parameters = component_parameters | derived_parameters
+                self.bns_convert()
+                self.assertEqual(self.parameters["lambda_1"], 0.0)
+                self.assertEqual(
+                    self.parameters["lambda_2"],
+                    component_parameters["lambda_2"],
+                )
+
 
 class TestGenerateAllParameters(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

This pull request prevents repeated binary-neutron-star parameter conversion from overwriting a complete pair of explicitly supplied component tidal deformabilities.

When both `lambda_1` and `lambda_2` are present and non-`None`, the converter now preserves them instead of reconstructing them from `lambda_tilde` or `delta_lambda_tilde`. Derived-only, partial-component, and `None` inputs continue through the existing reconstruction paths.

The regression uses the reported component values and covers both mixed forms: `lambda_tilde` alone and `lambda_tilde` with `delta_lambda_tilde`. Before the fix, these changed `lambda_1=0.0` to approximately `0.3695` and `-2.46e-14`, respectively.

This does not add numerical clamping, consistency validation, or waveform changes.

Fixes #1114

## Testing

- `pytest -q test/gw/conversion_test.py` — 65 passed, 2 subtests passed
- Existing derived-only and partial-component conversion controls
- Bilby-pinned flake8 and codespell checks
- `git diff --check`

This is a draft pending final author review and maintainer confirmation of the narrowly scoped precedence behavior.
