### PR TITLE
BUG: Validate PriorDict assignments

### DIFF
--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -60,6 +60,14 @@ class PriorDict(dict):
     def __hash__(self):
         return hash(str(self))
 
+    def __setitem__(self, key, value):
+        if not isinstance(value, (Prior, int, float, str, dict)):
+            raise TypeError(
+                "Unable to parse prior, bad entry: {} "
+                "= {} of type {}".format(key, value, type(value))
+            )
+        super().__setitem__(key, value)
+
     @xp_wrap
     def evaluate_constraints(self, sample, *, xp=None):
         out_sample = self.conversion_function(sample)

--- a/test/core/prior/dict_test.py
+++ b/test/core/prior/dict_test.py
@@ -79,6 +79,11 @@ class TestPriorDict(unittest.TestCase):
     def test_prior_set_has_expected_priors(self):
         self.assertDictEqual(self.priors, dict(self.prior_set_from_dict))
 
+    def test_assignment_rejects_invalid_prior_value(self):
+        expected_error = "Unable to parse prior, bad entry"
+        with self.assertRaisesRegex(TypeError, expected_error):
+            self.prior_set_from_dict["Om0"] = np.array(0.30966)
+
     def test_read_from_file(self):
         expected = dict(
             mass_1=bilby.core.prior.Constraint(


### PR DESCRIPTION
Closes #1111

Reject unsupported values assigned to `PriorDict` with the same `TypeError` used during constructor parsing. This prevents invalid entries such as zero-dimensional NumPy arrays from remaining visible in the dictionary while silently disappearing from `sample()` output.

Tested with the full `test/core/prior/dict_test.py` suite (37 passed), including a regression that fails on the original source.
