### PR TITLE
Pop the frequency bin edges for the BNS RB source model to match the BBH case

### DIFF
--- a/bilby/gw/source.py
+++ b/bilby/gw/source.py
@@ -783,6 +783,7 @@ def lal_binary_neutron_star_relative_binning(
     waveform_kwargs.update(kwargs)
 
     if fiducial == 1:
+        _ = waveform_kwargs.pop("frequency_bin_edges", None)
         return _base_lal_cbc_fd_waveform(
             frequency_array=frequency_array, mass_1=mass_1, mass_2=mass_2,
             luminosity_distance=luminosity_distance, theta_jn=theta_jn, phase=phase,

--- a/test/gw/source_test.py
+++ b/test/gw/source_test.py
@@ -620,6 +620,23 @@ class TestRelbinBBH(unittest.TestCase):
             dict,
         )
 
+    def test_relbin_fiducial_bbh_ignores_frequency_bin_edges(self):
+        """
+        Once bins are set up, ``RelativeBinningGravitationalWaveTransient``
+        leaves ``frequency_bin_edges`` in the waveform generator's persistent
+        ``waveform_arguments``, so any later fiducial (full-resolution) call
+        is made with it still present. The fiducial branch must drop it
+        rather than pass it through as an unused kwarg.
+        """
+        self.parameters.update(self.waveform_kwargs_fiducial)
+        self.parameters["frequency_bin_edges"] = np.arange(20, 1500, 50)
+        self.assertIsInstance(
+            bilby.gw.source.lal_binary_black_hole_relative_binning(
+                self.frequency_array, **self.parameters
+            ),
+            dict,
+        )
+
     def test_relbin_bbh_xpprecession_version(self):
         self.parameters.update(self.waveform_kwargs_fiducial)
         self.parameters["waveform_approximant"] = "IMRPhenomXP"
@@ -696,6 +713,26 @@ class TestRelbinBNS(unittest.TestCase):
                 self.frequency_array,
                 **self.parameters,
                 **self.waveform_kwargs_binned,
+            ),
+            dict,
+        )
+
+    def test_relbin_fiducial_bns_ignores_frequency_bin_edges(self):
+        """
+        Regression test for the missing ``frequency_bin_edges`` pop in the
+        fiducial branch (unlike the BBH counterpart, which already drops it).
+        Once bins are set up, ``RelativeBinningGravitationalWaveTransient``
+        leaves ``frequency_bin_edges`` in the waveform generator's persistent
+        ``waveform_arguments``, so any later fiducial (full-resolution) call
+        -- e.g. from an iterative fiducial-parameter update, or an external
+        Fisher-matrix calculation -- is made with it still present. Before the
+        fix this raised the "unused waveform kwargs" ``ValueError``.
+        """
+        self.parameters.update(self.waveform_kwargs_fiducial)
+        self.parameters["frequency_bin_edges"] = np.arange(20, 1500, 50)
+        self.assertIsInstance(
+            bilby.gw.source.lal_binary_neutron_star_relative_binning(
+                self.frequency_array, **self.parameters
             ),
             dict,
         )


### PR DESCRIPTION
In [this line](https://github.com/bilby-dev/bilby/blob/main/bilby/gw/source.py#L746) of `lal_binary_black_hole_relative_binning`, BBH RB source model pops the `frequency_bin_edges`. However, the same pop is [not applied to the BNS RB source model](https://github.com/bilby-dev/bilby/blob/main/bilby/gw/source.py#L786). In the past, this raised a warning, but since 9d7efe08, this is now a ValueError. AFAICT, this means This PR adds the pop to enable use of the BNS RB likelihood. 