### PR TITLE
BUG: Function Parameter Inference

### DIFF
--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -102,7 +102,7 @@ def infer_args_from_function_except_n_args(func, n=1):
         inspect.signature(func).parameters.values()
         if not parameter.kind in (
             inspect.Parameter.VAR_POSITIONAL,
-            inspect.Parameter.VAR_KEYWROD
+            inspect.Parameter.VAR_KEYWORD
         )
     ]
 

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -99,7 +99,7 @@ def infer_args_from_function_except_n_args(func, n=1):
     parameters = [
         parameter.name for parameter in
         inspect.signature(func).parameters.values()
-        if not parameter.kind in (
+        if parameter.kind not in (
             inspect.Parameter.VAR_POSITIONAL,
             inspect.Parameter.VAR_KEYWORD
         )

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -57,8 +57,6 @@ def infer_args_from_function_except_n_args(func, n=1):
     first n of these, returns a list of arguments from the function's
     signature.
 
-    Throws out `*args` and `**kwargs` type arguments.
-
     Parameters
     ==========
     func : function or method
@@ -75,7 +73,8 @@ def infer_args_from_function_except_n_args(func, n=1):
     ================
     This function is intended to allow the handling of named arguments
     in both functions and methods; this is important, since the first
-    argument of an instance method will be the instance.
+    argument of an instance method will be the instance. It throws out *args
+    and **kwargs style arguments.
 
     See Also
     ========

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -31,12 +31,11 @@ def infer_parameters_from_function(func):
     This allows the reference to the instance (conventionally named `self`)
     to be removed.
     """
-    if isinstance(func, (types.MethodType, types.BuiltinMethodType)):
-        return infer_args_from_function_except_n_args(func=func, n=2)
-    elif isinstance(func, (types.FunctionType, types.BuiltinFunctionType)):
-        return _infer_args_from_function_except_for_first_arg(func=func)
-    else:
+
+    if not callable(func):
         raise ValueError("This doesn't look like a function.")
+
+    return _infer_args_from_function_except_for_first_arg(func=func)
 
 
 def infer_args_from_method(method):
@@ -50,13 +49,16 @@ def infer_args_from_method(method):
     =======
     list: A list of strings with the parameters
     """
-    return infer_args_from_function_except_n_args(func=method, n=1)
+
+    return infer_args_from_function_except_n_args(func=method)
 
 
 def infer_args_from_function_except_n_args(func, n=1):
     """ Inspects a function to find its arguments, and ignoring the
     first n of these, returns a list of arguments from the function's
     signature.
+
+    Throws out `*args` and `**kwargs` type arguments.
 
     Parameters
     ==========
@@ -94,7 +96,15 @@ def infer_args_from_function_except_n_args(func, n=1):
         ['c', 'd']
 
     """
-    parameters = inspect.getfullargspec(func).args
+
+    parameters = [
+        parameter.name for parameter in inspect.signature(func).values()
+        if not parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWROD
+        )
+    ]
+
     del parameters[:n]
     return parameters
 

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -31,9 +31,9 @@ def infer_parameters_from_function(func):
     This allows the reference to the instance (conventionally named `self`)
     to be removed.
     """
-    if isinstance(func, types.MethodType):
+    if isinstance(func, (types.MethodType, types.BuiltinMethodType)):
         return infer_args_from_function_except_n_args(func=func, n=2)
-    elif isinstance(func, types.FunctionType):
+    elif isinstance(func, (types.FunctionType, types.BuiltinFunctionType)):
         return _infer_args_from_function_except_for_first_arg(func=func)
     else:
         raise ValueError("This doesn't look like a function.")

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -98,7 +98,8 @@ def infer_args_from_function_except_n_args(func, n=1):
     """
 
     parameters = [
-        parameter.name for parameter in inspect.signature(func).values()
+        parameter.name for parameter in
+        inspect.signature(func).parameters.values()
         if not parameter.kind in (
             inspect.Parameter.VAR_POSITIONAL,
             inspect.Parameter.VAR_KEYWROD

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -11,8 +11,8 @@ def infer_parameters_from_function(func):
 
     Parameters
     ==========
-    func: function or method
-       The function or method for which the parameters should be inferred.
+    func: Callable
+       The callable object for which the parameters should be inferred.
 
     Returns
     =======
@@ -21,14 +21,12 @@ def infer_parameters_from_function(func):
     Raises
     ======
     ValueError
-       If the object passed to the function is neither a function nor a method.
+       If the object passed to the function is not callable.
 
     Notes
     =====
-    In order to handle methods the `type` of the function is checked, and
-    if a method has been passed the first *two* arguments are removed rather than just the first one.
-    This allows the reference to the instance (conventionally named `self`)
-    to be removed.
+    If a class method is passed, this function will additionally strip the
+    reference to the instance (conventionally named `self`).
     """
 
     if not callable(func):

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -1,5 +1,4 @@
 import inspect
-import types
 
 
 def infer_parameters_from_function(func):
@@ -50,7 +49,7 @@ def infer_args_from_method(method):
     list: A list of strings with the parameters
     """
 
-    return infer_args_from_function_except_n_args(func=method)
+    return infer_args_from_function_except_n_args(func=method, n=0)
 
 
 def infer_args_from_function_except_n_args(func, n=1):

--- a/test/core/utils_test.py
+++ b/test/core/utils_test.py
@@ -112,6 +112,19 @@ class TestInferParameters(unittest.TestCase):
         del self.source1
         del self.source2
 
+    def test_builtin_function(self):
+        expected = [
+            "mode",
+            "buffering",
+            "encoding",
+            "errors",
+            "newline",
+            "closefd",
+            "opener"
+        ]
+        actual = utils.infer_parameters_from_function(open)
+        self.assertListEqual(expected, actual)
+
     def test_args_kwargs_handling(self):
         expected = ["a", "b"]
         actual = utils.infer_parameters_from_function(self.source1)


### PR DESCRIPTION
Currently, the [`infer_parameters_from_function`](https://github.com/bilby-dev/bilby/blob/0e77aa01f2fb5f2432edcd76cd764175aac4b7a7/bilby/core/utils/introspection.py#L5) function fails for functions coming from python C-extensions since these functions are classed as `builtin_function_or_method`.

To fix this, this PR simply expands the `isinstance` check to inclue `types.BuiltinFunctionType` and `types.BuiltinMethodType` which allows these functions to be included, assuming that they have signature information for inspect to find.