### PR TITLE
ENH(sampler): specify expected outputs for emcee

### DIFF
--- a/bilby/core/sampler/emcee.py
+++ b/bilby/core/sampler/emcee.py
@@ -423,6 +423,31 @@ class Emcee(MCMCSampler):
         self.result.walkers = self.sampler.chain
         return self.result
 
+    @classmethod
+    def get_expected_outputs(cls, outdir=None, label=None):
+        """Get lists of the expected outputs directories and files.
+
+        Parameters
+        ----------
+        outdir : str
+            The output directory.
+        label : str
+            The label for the run.
+
+        Returns
+        -------
+        list
+            List of file names produced by the sampler.
+        list
+            List of directory names produced by the sampler.
+        """
+        run_dir = os.path.join(outdir, f"emcee_{label}")
+        filenames = [
+            os.path.join(run_dir, "chain.dat"),
+            os.path.join(run_dir, "sampler.pickle"),
+        ]
+        return filenames, [run_dir]
+
     def _generate_result(self):
         self.result.nburn = self.nburn
         self.calc_likelihood_count()

--- a/test/core/sampler/emcee_test.py
+++ b/test/core/sampler/emcee_test.py
@@ -70,6 +70,18 @@ class TestEmcee(unittest.TestCase):
             self.sampler.kwargs = new_kwargs
             self.assertDictEqual(expected, self.sampler.kwargs)
 
+    def test_expected_output_files(self):
+        expected_filenames = [
+            "outdir/emcee_output_test/chain.dat",
+            "outdir/emcee_output_test/sampler.pickle",
+        ]
+        expected_dirs = [
+            "outdir/emcee_output_test"
+        ]
+        filenames, dirs = self.sampler.get_expected_outputs(outdir="outdir", label="output_test")
+        self.assertListEqual(expected_filenames, filenames)
+        self.assertListEqual(expected_dirs, dirs)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes https://github.com/bilby-dev/bilby/issues/804 and replaces https://github.com/bilby-dev/bilby/pull/1073 which was closed by the author.