### PR TITLE
BUG(dynesty): only close figures created during plot_current_state

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -16,6 +16,7 @@ from ..utils import (
     logger,
     safe_file_dump,
 )
+from ..utils.plotting import _close_new_figures
 from . import dynesty_utils
 from .base_sampler import NestedSampler, Sampler, _SamplingContainer, signal_wrapper
 
@@ -846,102 +847,96 @@ class Dynesty(NestedSampler):
         """
         if self.check_point_plot:
             import dynesty.plotting as dyplot
-            import matplotlib.pyplot as plt
 
             labels = [label.replace("_", " ") for label in self.search_parameter_keys]
-            figures_before = set(plt.get_fignums())
-            try:
-                filename = f"{self.outdir}/{self.label}_checkpoint_trace.png"
-                fig = dyplot.traceplot(self.sampler.results, labels=labels)[0]
-                fig.tight_layout()
-                fig.savefig(filename)
-            except (
-                RuntimeError,
-                np.linalg.LinAlgError,
-                ValueError,
-                OverflowError,
-            ) as e:
-                logger.warning(e)
-                logger.warning("Failed to create dynesty state plot at checkpoint")
-            except Exception as e:
-                logger.warning(
-                    f"Unexpected error {e} in dynesty plotting. "
-                    "Please report at github.com/bilby-dev/bilby/issues"
-                )
-            finally:
-                for figure_number in set(plt.get_fignums()) - figures_before:
-                    plt.close(figure_number)
-            figures_before = set(plt.get_fignums())
-            try:
-                filename = f"{self.outdir}/{self.label}_checkpoint_trace_unit.png"
-                from copy import deepcopy
+            with _close_new_figures():
+                try:
+                    filename = f"{self.outdir}/{self.label}_checkpoint_trace.png"
+                    fig = dyplot.traceplot(self.sampler.results, labels=labels)[0]
+                    fig.tight_layout()
+                    fig.savefig(filename)
+                except (
+                    RuntimeError,
+                    np.linalg.LinAlgError,
+                    ValueError,
+                    OverflowError,
+                ) as e:
+                    logger.warning(e)
+                    logger.warning("Failed to create dynesty state plot at checkpoint")
+                except Exception as e:
+                    logger.warning(
+                        f"Unexpected error {e} in dynesty plotting. "
+                        "Please report at github.com/bilby-dev/bilby/issues"
+                    )
 
-                from dynesty.utils import results_substitute
+            with _close_new_figures():
+                try:
+                    filename = f"{self.outdir}/{self.label}_checkpoint_trace_unit.png"
+                    from copy import deepcopy
 
-                temp = deepcopy(self.sampler.results)
-                temp = results_substitute(temp, dict(samples=temp["samples_u"]))
-                fig = dyplot.traceplot(temp, labels=labels)[0]
-                fig.tight_layout()
-                fig.savefig(filename)
-            except (
-                RuntimeError,
-                np.linalg.LinAlgError,
-                ValueError,
-                OverflowError,
-            ) as e:
-                logger.warning(e)
-                logger.warning("Failed to create dynesty unit state plot at checkpoint")
-            except Exception as e:
-                logger.warning(
-                    f"Unexpected error {e} in dynesty plotting. "
-                    "Please report at github.com/bilby-dev/bilby/issues"
-                )
-            finally:
-                for figure_number in set(plt.get_fignums()) - figures_before:
-                    plt.close(figure_number)
-            figures_before = set(plt.get_fignums())
-            try:
-                filename = f"{self.outdir}/{self.label}_checkpoint_run.png"
-                fig, _ = dyplot.runplot(
-                    self.sampler.results, logplot=False, use_math_text=False
-                )
-                fig.tight_layout()
-                fig.savefig(filename)
-            except (
-                RuntimeError,
-                np.linalg.LinAlgError,
-                ValueError,
-                OverflowError,
-            ) as e:
-                logger.warning(e)
-                logger.warning("Failed to create dynesty run plot at checkpoint")
-            except Exception as e:
-                logger.warning(
-                    f"Unexpected error {e} in dynesty plotting. "
-                    "Please report at github.com/bilby-dev/bilby/issues"
-                )
-            finally:
-                for figure_number in set(plt.get_fignums()) - figures_before:
-                    plt.close(figure_number)
-            figures_before = set(plt.get_fignums())
-            try:
-                filename = f"{self.outdir}/{self.label}_checkpoint_stats.png"
-                fig, _ = dynesty_stats_plot(self.sampler)
-                fig.tight_layout()
-                fig.savefig(filename)
-            except (RuntimeError, ValueError, OverflowError) as e:
-                logger.warning(e)
-                logger.warning("Failed to create dynesty stats plot at checkpoint")
-            except DynestySetupError:
-                logger.debug("Cannot create Dynesty stats plot with dynamic sampler.")
-            except Exception as e:
-                logger.warning(
-                    f"Unexpected error {e} in dynesty plotting. "
-                    "Please report at github.com/bilby-dev/bilby/issues"
-                )
-            finally:
-                for figure_number in set(plt.get_fignums()) - figures_before:
-                    plt.close(figure_number)
+                    from dynesty.utils import results_substitute
+
+                    temp = deepcopy(self.sampler.results)
+                    temp = results_substitute(temp, dict(samples=temp["samples_u"]))
+                    fig = dyplot.traceplot(temp, labels=labels)[0]
+                    fig.tight_layout()
+                    fig.savefig(filename)
+                except (
+                    RuntimeError,
+                    np.linalg.LinAlgError,
+                    ValueError,
+                    OverflowError,
+                ) as e:
+                    logger.warning(e)
+                    logger.warning(
+                        "Failed to create dynesty unit state plot at checkpoint"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Unexpected error {e} in dynesty plotting. "
+                        "Please report at github.com/bilby-dev/bilby/issues"
+                    )
+
+            with _close_new_figures():
+                try:
+                    filename = f"{self.outdir}/{self.label}_checkpoint_run.png"
+                    fig, _ = dyplot.runplot(
+                        self.sampler.results, logplot=False, use_math_text=False
+                    )
+                    fig.tight_layout()
+                    fig.savefig(filename)
+                except (
+                    RuntimeError,
+                    np.linalg.LinAlgError,
+                    ValueError,
+                    OverflowError,
+                ) as e:
+                    logger.warning(e)
+                    logger.warning("Failed to create dynesty run plot at checkpoint")
+                except Exception as e:
+                    logger.warning(
+                        f"Unexpected error {e} in dynesty plotting. "
+                        "Please report at github.com/bilby-dev/bilby/issues"
+                    )
+
+            with _close_new_figures():
+                try:
+                    filename = f"{self.outdir}/{self.label}_checkpoint_stats.png"
+                    fig, _ = dynesty_stats_plot(self.sampler)
+                    fig.tight_layout()
+                    fig.savefig(filename)
+                except (RuntimeError, ValueError, OverflowError) as e:
+                    logger.warning(e)
+                    logger.warning("Failed to create dynesty stats plot at checkpoint")
+                except DynestySetupError:
+                    logger.debug(
+                        "Cannot create Dynesty stats plot with dynamic sampler."
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Unexpected error {e} in dynesty plotting. "
+                        "Please report at github.com/bilby-dev/bilby/issues"
+                    )
 
     def _run_test(self):
         """Run the sampler very briefly as a sanity test that it works."""

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -849,94 +849,71 @@ class Dynesty(NestedSampler):
             import dynesty.plotting as dyplot
 
             labels = [label.replace("_", " ") for label in self.search_parameter_keys]
-            with _close_new_figures():
-                try:
-                    filename = f"{self.outdir}/{self.label}_checkpoint_trace.png"
-                    fig = dyplot.traceplot(self.sampler.results, labels=labels)[0]
-                    fig.tight_layout()
-                    fig.savefig(filename)
-                except (
-                    RuntimeError,
-                    np.linalg.LinAlgError,
-                    ValueError,
-                    OverflowError,
-                ) as e:
-                    logger.warning(e)
-                    logger.warning("Failed to create dynesty state plot at checkpoint")
-                except Exception as e:
-                    logger.warning(
-                        f"Unexpected error {e} in dynesty plotting. "
-                        "Please report at github.com/bilby-dev/bilby/issues"
-                    )
 
-            with _close_new_figures():
-                try:
-                    filename = f"{self.outdir}/{self.label}_checkpoint_trace_unit.png"
-                    from copy import deepcopy
+            def _generate_checkpoint_plot(plot_func, suffix, description):
+                """Generate, save, and handle errors for a checkpoint plot."""
+                with _close_new_figures():
+                    try:
+                        filename = f"{self.outdir}/{self.label}_checkpoint_{suffix}.png"
 
-                    from dynesty.utils import results_substitute
+                        # All dynesty plotters return (fig, axes).
+                        fig = plot_func()[0]
 
-                    temp = deepcopy(self.sampler.results)
-                    temp = results_substitute(temp, dict(samples=temp["samples_u"]))
-                    fig = dyplot.traceplot(temp, labels=labels)[0]
-                    fig.tight_layout()
-                    fig.savefig(filename)
-                except (
-                    RuntimeError,
-                    np.linalg.LinAlgError,
-                    ValueError,
-                    OverflowError,
-                ) as e:
-                    logger.warning(e)
-                    logger.warning(
-                        "Failed to create dynesty unit state plot at checkpoint"
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Unexpected error {e} in dynesty plotting. "
-                        "Please report at github.com/bilby-dev/bilby/issues"
-                    )
+                        fig.tight_layout()
+                        fig.savefig(filename)
 
-            with _close_new_figures():
-                try:
-                    filename = f"{self.outdir}/{self.label}_checkpoint_run.png"
-                    fig, _ = dyplot.runplot(
-                        self.sampler.results, logplot=False, use_math_text=False
-                    )
-                    fig.tight_layout()
-                    fig.savefig(filename)
-                except (
-                    RuntimeError,
-                    np.linalg.LinAlgError,
-                    ValueError,
-                    OverflowError,
-                ) as e:
-                    logger.warning(e)
-                    logger.warning("Failed to create dynesty run plot at checkpoint")
-                except Exception as e:
-                    logger.warning(
-                        f"Unexpected error {e} in dynesty plotting. "
-                        "Please report at github.com/bilby-dev/bilby/issues"
-                    )
+                    except (
+                        RuntimeError,
+                        np.linalg.LinAlgError,
+                        ValueError,
+                        OverflowError,
+                    ) as e:
+                        logger.warning(e)
+                        logger.warning(
+                            f"Failed to create dynesty {description} plot at checkpoint"
+                        )
+                    except DynestySetupError:
+                        # specifically for dynesty_stats_plot
+                        logger.debug(
+                            "Cannot create Dynesty stats plot with dynamic sampler."
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Unexpected error {e} in dynesty plotting. "
+                            "Please report at github.com/bilby-dev/bilby/issues"
+                        )
 
-            with _close_new_figures():
-                try:
-                    filename = f"{self.outdir}/{self.label}_checkpoint_stats.png"
-                    fig, _ = dynesty_stats_plot(self.sampler)
-                    fig.tight_layout()
-                    fig.savefig(filename)
-                except (RuntimeError, ValueError, OverflowError) as e:
-                    logger.warning(e)
-                    logger.warning("Failed to create dynesty stats plot at checkpoint")
-                except DynestySetupError:
-                    logger.debug(
-                        "Cannot create Dynesty stats plot with dynamic sampler."
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Unexpected error {e} in dynesty plotting. "
-                        "Please report at github.com/bilby-dev/bilby/issues"
-                    )
+            def _get_unit_trace_plot():
+                from copy import deepcopy
+
+                from dynesty.utils import results_substitute
+
+                temp = deepcopy(self.sampler.results)
+                temp = results_substitute(temp, dict(samples=temp["samples_u"]))
+                return dyplot.traceplot(temp, labels=labels)
+
+            _generate_checkpoint_plot(
+                lambda: dyplot.traceplot(self.sampler.results, labels=labels),
+                suffix="trace",
+                description="state",
+            )
+            _generate_checkpoint_plot(
+                _get_unit_trace_plot,
+                suffix="trace_unit",
+                description="unit state",
+            )
+            _generate_checkpoint_plot(
+                lambda: dyplot.runplot(
+                    self.sampler.results, logplot=False, use_math_text=False
+                ),
+                suffix="run",
+                description="run",
+            )
+            _generate_checkpoint_plot(
+                lambda: dynesty_stats_plot(self.sampler),
+                suffix="stats",
+                description="stats",
+            )
 
     def _run_test(self):
         """Run the sampler very briefly as a sanity test that it works."""

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -849,6 +849,7 @@ class Dynesty(NestedSampler):
             import matplotlib.pyplot as plt
 
             labels = [label.replace("_", " ") for label in self.search_parameter_keys]
+            figures_before = set(plt.get_fignums())
             try:
                 filename = f"{self.outdir}/{self.label}_checkpoint_trace.png"
                 fig = dyplot.traceplot(self.sampler.results, labels=labels)[0]
@@ -868,7 +869,9 @@ class Dynesty(NestedSampler):
                     "Please report at github.com/bilby-dev/bilby/issues"
                 )
             finally:
-                plt.close("all")
+                for figure_number in set(plt.get_fignums()) - figures_before:
+                    plt.close(figure_number)
+            figures_before = set(plt.get_fignums())
             try:
                 filename = f"{self.outdir}/{self.label}_checkpoint_trace_unit.png"
                 from copy import deepcopy
@@ -894,14 +897,16 @@ class Dynesty(NestedSampler):
                     "Please report at github.com/bilby-dev/bilby/issues"
                 )
             finally:
-                plt.close("all")
+                for figure_number in set(plt.get_fignums()) - figures_before:
+                    plt.close(figure_number)
+            figures_before = set(plt.get_fignums())
             try:
                 filename = f"{self.outdir}/{self.label}_checkpoint_run.png"
                 fig, _ = dyplot.runplot(
                     self.sampler.results, logplot=False, use_math_text=False
                 )
                 fig.tight_layout()
-                plt.savefig(filename)
+                fig.savefig(filename)
             except (
                 RuntimeError,
                 np.linalg.LinAlgError,
@@ -916,12 +921,14 @@ class Dynesty(NestedSampler):
                     "Please report at github.com/bilby-dev/bilby/issues"
                 )
             finally:
-                plt.close("all")
+                for figure_number in set(plt.get_fignums()) - figures_before:
+                    plt.close(figure_number)
+            figures_before = set(plt.get_fignums())
             try:
                 filename = f"{self.outdir}/{self.label}_checkpoint_stats.png"
                 fig, _ = dynesty_stats_plot(self.sampler)
                 fig.tight_layout()
-                plt.savefig(filename)
+                fig.savefig(filename)
             except (RuntimeError, ValueError, OverflowError) as e:
                 logger.warning(e)
                 logger.warning("Failed to create dynesty stats plot at checkpoint")
@@ -933,7 +940,8 @@ class Dynesty(NestedSampler):
                     "Please report at github.com/bilby-dev/bilby/issues"
                 )
             finally:
-                plt.close("all")
+                for figure_number in set(plt.get_fignums()) - figures_before:
+                    plt.close(figure_number)
 
     def _run_test(self):
         """Run the sampler very briefly as a sanity test that it works."""

--- a/bilby/core/utils/plotting.py
+++ b/bilby/core/utils/plotting.py
@@ -1,8 +1,22 @@
 import functools
 import os
 import shutil
+from contextlib import contextmanager
 
 from .log import logger
+
+
+@contextmanager
+def _close_new_figures():
+    """Close figures created in this context, preserving existing figures."""
+    import matplotlib.pyplot as plt
+
+    existing_figures = set(plt.get_fignums())
+    try:
+        yield
+    finally:
+        for figure_number in set(plt.get_fignums()) - existing_figures:
+            plt.close(figure_number)
 
 
 def latex_plot_format(func):

--- a/test/core/sampler/dynesty_test.py
+++ b/test/core/sampler/dynesty_test.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import unittest
 from copy import deepcopy
+from unittest import mock
 
 import bilby
 import bilby.core.sampler.dynesty
@@ -145,6 +146,54 @@ class TestDynesty(unittest.TestCase):
 
     def test_run_test_runs(self):
         self.sampler._run_test()
+
+    def test_plot_current_state_only_closes_figures_it_creates(self):
+        import matplotlib.pyplot as plt
+
+        user_figure = plt.figure()
+        self.addCleanup(plt.close, user_figure)
+        user_figure_number = user_figure.number
+        created_figures = []
+
+        def make_plot(*args, **kwargs):
+            self.assertEqual(set(plt.get_fignums()), {user_figure_number})
+            figure = plt.figure()
+            created_figures.append(figure)
+            return figure, None
+
+        trace_plot_calls = 0
+
+        def make_trace_plot(*args, **kwargs):
+            nonlocal trace_plot_calls
+            trace_plot_calls += 1
+            plot = make_plot()
+            if trace_plot_calls == 1:
+                raise ValueError("Failed after creating a figure")
+            return plot
+
+        self.sampler.sampler = mock.Mock(
+            results={"samples_u": np.zeros((1, self.sampler.ndim))}
+        )
+        with (
+            mock.patch("dynesty.plotting.traceplot", side_effect=make_trace_plot),
+            mock.patch("dynesty.plotting.runplot", side_effect=make_plot),
+            mock.patch(
+                "dynesty.utils.results_substitute",
+                side_effect=lambda results, substitutions: results,
+            ),
+            mock.patch.object(
+                bilby.core.sampler.dynesty,
+                "dynesty_stats_plot",
+                side_effect=make_plot,
+            ),
+            mock.patch("matplotlib.figure.Figure.savefig"),
+        ):
+            self.sampler.plot_current_state()
+
+        self.assertTrue(plt.fignum_exists(user_figure_number))
+        self.assertTrue(
+            all(not plt.fignum_exists(figure.number) for figure in created_figures)
+        )
 
     @parameterized.parameterized.expand((
         ("unif", "single"),

--- a/test/core/utils_test.py
+++ b/test/core/utils_test.py
@@ -20,6 +20,7 @@ import warnings
 import bilby
 from bilby.core import utils
 from bilby.core.utils import global_meta_data
+from bilby.core.utils.plotting import _close_new_figures
 
 
 class TestConstants(unittest.TestCase):
@@ -280,6 +281,30 @@ class TestReflect(unittest.TestCase):
         xprime = self.xp.asarray([-1.9, -1.5, -1.1])
         x = self.xp.asarray([0.1, 0.5, 0.9])
         self.assertTrue(np.testing.assert_allclose(utils.reflect(xprime), x) is None)
+
+
+class TestCloseNewFigures(unittest.TestCase):
+    def setUp(self):
+        self.existing_figure = plt.figure()
+
+    def tearDown(self):
+        plt.close(self.existing_figure)
+
+    def test_closes_only_new_figures(self):
+        with _close_new_figures():
+            new_figure = plt.figure()
+
+        self.assertTrue(plt.fignum_exists(self.existing_figure.number))
+        self.assertFalse(plt.fignum_exists(new_figure.number))
+
+    def test_closes_new_figures_after_error(self):
+        with self.assertRaises(RuntimeError):
+            with _close_new_figures():
+                new_figure = plt.figure()
+                raise RuntimeError
+
+        self.assertTrue(plt.fignum_exists(self.existing_figure.number))
+        self.assertFalse(plt.fignum_exists(new_figure.number))
 
 
 class TestLatexPlotFormat(unittest.TestCase):


### PR DESCRIPTION
Closes https://github.com/bilby-dev/bilby/issues/768

I chose to use `plt.get_fignums()` to close all figures created in the functions rather than relying on just closing `fig`.