### PR TITLE
ENH(sampler): improve sampling interruption handling

### DIFF
--- a/bilby/core/sampler/base_sampler.py
+++ b/bilby/core/sampler/base_sampler.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import shutil
 import signal
-import sys
 import tempfile
 import time
 from copy import deepcopy
@@ -752,13 +751,21 @@ class Sampler(object):
         can be caught as a :code:`SystemExit`.
         """
         if self.npool in (1, None) or getattr(self, "pool", None) is not None:
+
+            self._interrupted = True
+            self._interruption_signum = signum
+
             self._log_interruption(signum=signum)
             self.write_current_state()
             self._close_pool()
+
             if self.hard_exit:
                 os._exit(self.exit_code)
-            else:
-                sys.exit(self.exit_code)
+            raise SystemExit(self.exit_code)
+
+    def _raise_if_interrupted(self, cause):
+        if getattr(self, "_interrupted", False):
+            raise SystemExit(self.exit_code) from cause
 
     def _close_pool(self):
         if getattr(self, "pool", None) is not None:

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -900,6 +900,7 @@ class Dynesty(NestedSampler):
                             "Cannot create Dynesty stats plot with dynamic sampler."
                         )
                     except Exception as e:
+                        self._raise_if_interrupted(e)
                         logger.warning(
                             f"Unexpected error {e} in dynesty plotting. "
                             "Please report at github.com/bilby-dev/bilby/issues"

--- a/test/core/sampler/base_sampler_test.py
+++ b/test/core/sampler/base_sampler_test.py
@@ -2,7 +2,7 @@ import copy
 import os
 import shutil
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from parameterized import parameterized
 
 import numpy as np
@@ -148,6 +148,35 @@ class TestSampler(unittest.TestCase):
         self.sampler._check_bad_value(
             val=np.nan_to_num(-np.inf), warning=False, theta=None, label=None
         )
+
+    def test_raise_if_interrupted(self):
+        error = RuntimeError("plotting failed")
+        self.sampler._interrupted = True
+
+        with self.assertRaises(SystemExit) as context:
+            self.sampler._raise_if_interrupted(error)
+
+        self.assertEqual(context.exception.code, self.sampler.exit_code)
+        self.assertIs(context.exception.__cause__, error)
+
+    def test_write_current_state_and_exit_records_interruption(self):
+        self.sampler.pool = None
+
+        with (
+            patch.object(self.sampler, "write_current_state"),
+            patch.object(self.sampler, "_close_pool"),
+            self.assertRaises(SystemExit),
+        ):
+            self.sampler.write_current_state_and_exit(signum=14)
+
+        self.assertTrue(self.sampler._interrupted)
+        self.assertEqual(self.sampler._interruption_signum, 14)
+
+    def test_raise_if_interrupted_not_interrupted(self):
+        self.sampler._interrupted = False
+
+        # This should return normally.
+        self.sampler._raise_if_interrupted(RuntimeError("plotting failed"))
 
 
 def test_get_expected_outputs():

--- a/test/core/sampler/dynesty_test.py
+++ b/test/core/sampler/dynesty_test.py
@@ -12,6 +12,7 @@ import numpy as np
 import parameterized
 from attr import define
 from scipy.stats import gamma, ks_1samp, uniform, powerlaw
+from unittest.mock import Mock, patch
 
 from bilby.core.sampler import dynesty_utils
 
@@ -269,6 +270,22 @@ class TestDynesty(unittest.TestCase):
         This is not an exhaustive test.
         """
         self.init_sampler(sample=sample, bound=bound)
+
+    def test_plotting_exception_does_not_swallow_interruption(self):
+        # Emulate error reported in https://github.com/bilby-dev/bilby/issues/758
+        error = SystemError(
+            "numpy.ndarray.__deepcopy__ returned a result with an error set"
+        )
+
+        self.sampler.sampler = Mock()
+        self.sampler._interrupted = True
+
+        with patch("dynesty.plotting.traceplot", side_effect=error):
+            with self.assertRaises(SystemExit) as context:
+                self.sampler.plot_current_state()
+
+        self.assertEqual(context.exception.code, self.sampler.exit_code)
+        self.assertIs(context.exception.__cause__, error)
 
 
 def test_get_expected_outputs():


### PR DESCRIPTION
Going through old issues, I thought I'd try to address https://github.com/bilby-dev/bilby/issues/758/.

The core issue is that plotting function catches any exception. If, as reported in the issue, the interrupts a function and causes it to raise an error, then this error is caught and the interrupt fails.

Removing the general Exception catching would fix this, but that is intentional in the plotting function.

Instead, I've added a smaller helper that checks if the run has been interrupted and, if so, raises the error rather than catching it.

Closes https://github.com/bilby-dev/bilby/issues/758