### PR TITLE
BUG(conversion): add time jitter if missing when generating all cbc parameters

### DIFF
--- a/bilby/gw/conversion.py
+++ b/bilby/gw/conversion.py
@@ -1650,6 +1650,18 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
     output_sample = fill_from_fixed_priors(output_sample, priors)
     output_sample, _ = base_conversion(output_sample)
     if likelihood is not None:
+        added_time_jitter = (
+            getattr(likelihood, "time_marginalization", False)
+            and getattr(likelihood, "jitter_time", False)
+            and "time_jitter" not in output_sample
+        )
+        if added_time_jitter:
+            # Injection parameters do not include time jitter.
+            # Use the centre of the jitter grid while calculating
+            # post-processing diagnostics.
+            logger.debug("Adding time jitter to sample for post-processing")
+            output_sample["time_jitter"] = 0.0
+
         compute_per_detector_log_likelihoods(
             samples=output_sample, likelihood=likelihood, npool=npool)
 
@@ -1692,6 +1704,9 @@ def _generate_all_cbc_parameters(sample, defaults, base_conversion,
                     .format(type(output_sample))
                 )
         compute_snrs(output_sample, likelihood, npool=npool)
+        # Remove the time jitter if it was added
+        if added_time_jitter:
+            output_sample.pop("time_jitter")
     for key, func in zip(["mass", "spin", "source frame"], [
             generate_mass_parameters, generate_spin_parameters,
             generate_source_frame_parameters]):

--- a/test/gw/conversion_test.py
+++ b/test/gw/conversion_test.py
@@ -533,12 +533,15 @@ class TestGenerateAllParameters(unittest.TestCase):
         )
         self.parameters["zenith"] = 0.0
         self.parameters["azimuth"] = 0.0
-        self.parameters["time_jitter"] = 0.0
         del self.parameters["ra"], self.parameters["dec"]
-        self.parameters = pd.DataFrame(self.parameters, index=range(1))
         initial_likelihood_parameters = dict(mass_1=-1.0)
         converted = bilby.gw.conversion.generate_all_bbh_parameters(
             sample=self.parameters, likelihood=likelihood, priors=priors
+        )
+        converted_with_time_jitter = bilby.gw.conversion.generate_all_bbh_parameters(
+            sample={**self.parameters, "time_jitter": 0.0},
+            likelihood=likelihood,
+            priors=priors,
         )
         extra_expected = [
             "geocent_time",
@@ -552,7 +555,13 @@ class TestGenerateAllParameters(unittest.TestCase):
         ]
         for key in extra_expected:
             self.assertIn(key, converted)
-        self.assertNotEqual(converted["mass_1"].values[0], initial_likelihood_parameters["mass_1"])
+        self.assertNotIn("time_jitter", converted)
+        for ifo in ifos:
+            np.testing.assert_allclose(
+                converted[f"{ifo.name}_log_likelihood"],
+                converted_with_time_jitter[f"{ifo.name}_log_likelihood"],
+            )
+        self.assertNotEqual(converted["mass_1"], initial_likelihood_parameters["mass_1"])
 
     def test_identity_generation_no_likelihood(self):
         test_fixed_prior = bilby.core.prior.PriorDict({


### PR DESCRIPTION
Following the changes to how we call the likelihood, time marginalization would lead to the conversion function failing if injection parameters are specified, as described in https://github.com/bilby-dev/bilby/issues/1020.

I've opted to handle this in the conversion function rather than forcing the user to add `time_jitter` to the injection parameters. Let me know what you think.

Closes https://github.com/bilby-dev/bilby/issues/1020