### PR TITLE
BUG(dynesty): check parameter keys match when resuming

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -18,7 +18,13 @@ from ..utils import (
 )
 from ..utils.plotting import _close_new_figures
 from . import dynesty_utils
-from .base_sampler import NestedSampler, Sampler, _SamplingContainer, signal_wrapper
+from .base_sampler import (
+    NestedSampler,
+    ResumeError,
+    Sampler,
+    _SamplingContainer,
+    signal_wrapper,
+)
 
 
 def _set_sampling_kwargs(args):
@@ -728,6 +734,23 @@ class Dynesty(NestedSampler):
                     )
                     return False
 
+                stored_parameter_keys = extras.get("search_parameter_keys")
+                if stored_parameter_keys is None:
+                    logger.warning(
+                        "The resume file does not contain search parameter order "
+                        "metadata. The order cannot be verified; this is expected "
+                        "for checkpoints created by older versions of Bilby."
+                    )
+                elif list(stored_parameter_keys) != self.search_parameter_keys:
+                    raise ResumeError(
+                        "Cannot resume the Dynesty run because the search parameter "
+                        "order differs from the checkpoint.\n"
+                        f"Checkpoint order: {list(stored_parameter_keys)}\n"
+                        f"Current order: {self.search_parameter_keys}\n"
+                        "Reconstruct the priors in the checkpoint order, or remove "
+                        "the checkpoint to start a new run."
+                    )
+
                 version_warning = (
                     "The {code} version has changed between runs. "
                     "This may cause unpredictable behaviour and/or failure. "
@@ -787,14 +810,13 @@ class Dynesty(NestedSampler):
             return
 
         check_directory_exists_and_if_not_mkdir(self.outdir)
+        metadata = dict(search_parameter_keys=list(self.search_parameter_keys))
         if hasattr(self, "start_time"):
             self._update_sampling_time()
-            metadata = dict(
+            metadata.update(
                 sampling_time=self.sampling_time,
                 start_time=self.start_time,
             )
-        else:
-            metadata = dict()
         versions = dict(bilby=bilby_version, dynesty=dynesty_version)
         self.sampler.pool = None
         self.sampler.mapper = map

--- a/test/core/sampler/dynesty_test.py
+++ b/test/core/sampler/dynesty_test.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import shutil
 import unittest
@@ -6,6 +7,7 @@ from unittest import mock
 
 import bilby
 import bilby.core.sampler.dynesty
+import dynesty
 import numpy as np
 import parameterized
 from attr import define
@@ -80,6 +82,66 @@ class TestDynesty(unittest.TestCase):
         del self.priors
         del self.sampler
         del self.dysampler
+
+    def read_mock_checkpoint(self, metadata):
+        checkpoint = mock.MagicMock(added_live=False)
+        versions = dict(bilby=bilby.__version__, dynesty=dynesty.__version__)
+        self.sampler.pool = None
+        with (
+            mock.patch("os.path.isfile", return_value=True),
+            mock.patch("os.stat", return_value=mock.MagicMock(st_size=1)),
+            mock.patch("builtins.open", mock.mock_open()),
+            mock.patch(
+                "dill.load", return_value=(checkpoint, versions, metadata.copy())
+            ),
+        ):
+            return self.sampler.read_saved_state(continuing=True)
+
+    def test_write_current_state_stores_search_parameter_keys(self):
+        self.sampler.sampler = self.dysampler
+        self.sampler.pool = None
+        with (
+            mock.patch("dill.pickles", return_value=True),
+            mock.patch.object(
+                bilby.core.sampler.dynesty, "safe_file_dump"
+            ) as safe_file_dump,
+        ):
+            self.sampler.write_current_state()
+
+        checkpoint = safe_file_dump.call_args.args[0]
+        assert checkpoint[2]["search_parameter_keys"] == ["a", "b"]
+
+    def test_read_saved_state_accepts_matching_search_parameter_keys(self):
+        metadata = dict(
+            search_parameter_keys=["a", "b"],
+            sampling_time=datetime.timedelta(),
+            start_time=datetime.datetime.now(),
+        )
+        assert self.read_mock_checkpoint(metadata)
+
+    def test_read_saved_state_rejects_changed_search_parameter_order(self):
+        metadata = dict(
+            search_parameter_keys=["b", "a"],
+            sampling_time=datetime.timedelta(),
+            start_time=datetime.datetime.now(),
+        )
+        with self.assertRaisesRegex(
+            bilby.core.sampler.base_sampler.ResumeError,
+            "search parameter order differs",
+        ):
+            self.read_mock_checkpoint(metadata)
+
+    def test_read_saved_state_allows_legacy_checkpoint(self):
+        metadata = dict(
+            sampling_time=datetime.timedelta(),
+            start_time=datetime.datetime.now(),
+        )
+        with mock.patch.object(bilby.core.sampler.dynesty.logger, "warning") as warning:
+            assert self.read_mock_checkpoint(metadata)
+        assert (
+            "does not contain search parameter order metadata"
+            in warning.call_args_list[0].args[0]
+        )
 
     def test_default_kwargs(self):
         """Only test the kwargs where we specify different defaults to dynesty"""


### PR DESCRIPTION
When resuming dynesty runs, if `search_parameter_keys` list can change order since it relies on the ordering from a dictionary. As reported in https://github.com/bilby-dev/bilby/issues/956, this can lead to invalid resume states.

This PR adds the keys to checkpoint metadata so I can be checked when resuming.

Closes https://github.com/bilby-dev/bilby/issues/956