### PR TITLE
MAINT: change default logging configuration

### DIFF
--- a/bilby/__init__.py
+++ b/bilby/__init__.py
@@ -16,7 +16,11 @@ https://bilby-dev.github.io/bilby/installation.html.
 """
 
 
+import logging
 import sys
+
+# Avoid configuring logging for applications that import bilby.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 from . import core, gw, hyper
 

--- a/bilby/core/utils/__init__.py
+++ b/bilby/core/utils/__init__.py
@@ -18,5 +18,3 @@ from .series import *
 
 #  Instantiate the default argument parser at runtime
 command_line_args, command_line_parser = set_up_command_line_arguments()
-#  Instantiate the default logging
-setup_logger(print_version=False, log_level=command_line_args.log_level)

--- a/bilby/core/utils/log.py
+++ b/bilby/core/utils/log.py
@@ -15,10 +15,10 @@ def setup_logger(outdir='.', label=None, log_level='INFO', print_version=False):
     ==========
     outdir, label: str
         If supplied, write the logging output to outdir/label.log
-    log_level: str, optional
+    log_level: str or int, optional
         ['debug', 'info', 'warning']
         Either a string from the list above, or an integer as specified
-        in https://docs.python.org/2/library/logging.html#logging-levels
+        in https://docs.python.org/3/library/logging.html#logging-levels
     print_version: bool
         If true, print version information
     """


### PR DESCRIPTION
Address https://github.com/bilby-dev/bilby/issues/834 by changing the logging configuration to only add the null logger by default.

This follows python best practices and makes it easier for downstream users to handle bilby logging.

Replaces https://github.com/bilby-dev/bilby/pull/1072 since it was closed by the author.