### PR TITLE
MAINT: remove python<3 check

### DIFF
--- a/bilby/__init__.py
+++ b/bilby/__init__.py
@@ -29,25 +29,3 @@ try:
     from ._version import version as __version__
 except ModuleNotFoundError:  # development mode
     __version__ = 'unknown'
-
-
-if sys.version_info < (3,):
-    raise ImportError(
-"""You are running bilby >= 0.6.4 on Python 2
-
-Bilby 0.6.4 and above are no longer compatible with Python 2, and you still
-ended up with this version installed. That's unfortunate; sorry about that.
-It should not have happened. Make sure you have pip >= 9.0 to avoid this kind
-of issue, as well as setuptools >= 24.2:
-
- $ pip install pip setuptools --upgrade
-
-Your choices:
-
-- Upgrade to Python 3.
-
-- Install an older version of bilby:
-
- $ pip install 'bilby<0.6.4'
-
-""")

--- a/bilby/__init__.py
+++ b/bilby/__init__.py
@@ -15,9 +15,6 @@ https://bilby-dev.github.io/bilby/installation.html.
 
 """
 
-
-import sys
-
 from . import core, gw, hyper
 
 from .core import utils, likelihood, prior, result, sampler


### PR DESCRIPTION
I noticed this check for Python < 3 still exists. Given Python 2.0 is long gone, I thought it best we removed it.