### PR TITLE
Add Welch PSD method option

### DIFF
--- a/bilby/gw/detector/psd.py
+++ b/bilby/gw/detector/psd.py
@@ -110,7 +110,7 @@ class PowerSpectralDensity(object):
     def from_frame_file(frame_file, psd_start_time, psd_duration,
                         fft_length=4, sampling_frequency=4096, roll_off=0.2,
                         overlap=0, channel=None, name=None, outdir=None,
-                        analysis_segment_start_time=None):
+                        analysis_segment_start_time=None, method='median'):
         """ Generate power spectral density from a frame file
 
         Parameters
@@ -138,6 +138,9 @@ class PowerSpectralDensity(object):
         analysis_segment_start_time: float, optional
             The start time of the analysis segment, if given, this data will
             be removed before creating the PSD.
+        method: str, optional
+            FFT averaging method passed to gwpy e.g. 'welch', 'median', 'bartlett'.
+            Defaults to 'median'.
 
         """
         strain = InterferometerStrainData(roll_off=roll_off)
@@ -146,14 +149,14 @@ class PowerSpectralDensity(object):
             channel=channel, sampling_frequency=sampling_frequency)
         frequency_array, psd_array = strain.create_power_spectral_density(
             fft_length=fft_length, name=name, outdir=outdir, overlap=overlap,
-            analysis_segment_start_time=analysis_segment_start_time)
+            analysis_segment_start_time=analysis_segment_start_time, method=method)
         return PowerSpectralDensity(frequency_array=frequency_array, psd_array=psd_array)
 
     @staticmethod
     def from_channel_name(channel, psd_start_time, psd_duration,
                           fft_length=4, sampling_frequency=4096, roll_off=0.2,
                           overlap=0, name=None, outdir=None,
-                          analysis_segment_start_time=None):
+                          analysis_segment_start_time=None, method='median'):
         """ Generate power spectral density from a given channel name
         by loading data using `strain_data.set_from_channel_name`
 
@@ -181,6 +184,9 @@ class PowerSpectralDensity(object):
         analysis_segment_start_time: float, optional
             The start time of the analysis segment, if given, this data will
             be removed before creating the PSD.
+        method: str, optional
+            FFT averaging method passed to gwpy e.g. 'welch', 'median', 'bartlett'.
+            Defaults to 'median'.
 
         """
         strain = InterferometerStrainData(roll_off=roll_off)
@@ -189,7 +195,7 @@ class PowerSpectralDensity(object):
             sampling_frequency=sampling_frequency)
         frequency_array, psd_array = strain.create_power_spectral_density(
             fft_length=fft_length, name=name, outdir=outdir, overlap=overlap,
-            analysis_segment_start_time=analysis_segment_start_time)
+            analysis_segment_start_time=analysis_segment_start_time, method=method)
         return PowerSpectralDensity(frequency_array=frequency_array, psd_array=psd_array)
 
     @staticmethod

--- a/bilby/gw/detector/strain_data.py
+++ b/bilby/gw/detector/strain_data.py
@@ -365,7 +365,7 @@ class InterferometerStrainData(object):
 
     def create_power_spectral_density(
             self, fft_length, overlap=0, name='unknown', outdir=None,
-            analysis_segment_start_time=None):
+            analysis_segment_start_time=None, method='median'):
         """ Use the time domain strain to generate a power spectral density
 
         This create a Tukey-windowed power spectral density and writes it to a
@@ -386,6 +386,9 @@ class InterferometerStrainData(object):
         analysis_segment_start_time: float
             The start time of the analysis segment, if given, this data will
             be removed before creating the PSD.
+        method: str
+            FFT averaging method passed to gwpy e.g. 'welch', 'median', 'bartlett'.
+            Defaults to 'median'.
 
         Returns
         =======
@@ -414,8 +417,11 @@ class InterferometerStrainData(object):
         logger.info(
             "Tukey window PSD data with alpha={}, roll off={}".format(
                 psd_alpha, self.roll_off))
+        if method == 'bartlett' and overlap != 0:
+            logger.warning(
+                "Bartlett method does not support overlap. Overlap will be ignored.")
         psd = strain.psd(
-            fftlength=fft_length, overlap=overlap, window=('tukey', psd_alpha))
+            method=method, fftlength=fft_length, overlap=overlap, window=('tukey', psd_alpha))
 
         if outdir:
             psd_file = '{}/{}_PSD_{}_{}.txt'.format(outdir, name, self.start_time, self.duration)


### PR DESCRIPTION
`bilby_pipe` allows for the Welch PSD averaging method to be defined so this adds this option to `bilby` to keep consistent. Allows for the averaging method to be defined following the available methods in `gwpy`: welch, median or bartlett. 